### PR TITLE
feat: Make modal draggable and responsive

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -404,24 +404,27 @@ body.dark .card .icon > i {
   right: 0;
   bottom: 0;
   background: rgba(44, 26, 73, 0.31);
-  display: flex;
-  align-items: center; /* ALIGN VERTICALLY CENTER */
-  justify-content: center; /* ALIGN HORIZONTALLY CENTER */
 }
 
 .ops-modal {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   min-width: 310px;
-  max-width: 800px; /* INCREASED MODAL WIDTH */
-  width: 96vw;
+  max-width: 800px;
+  width: 80vw;
+  max-height: 80vh;
   background: #fff;
   color: #1a1930;
   border-radius: 2rem;
   box-shadow: 0 6px 60px #5e24bb25, 0 0 0 2px #fff1;
   padding: 2.1rem 2.2rem 1.3rem 2.2rem;
-  position: relative; /* RELATIVE POSITIONING FOR CENTERING */
   transition: box-shadow 0.17s;
   cursor: default;
   z-index: 2222;
+  display: flex;
+  flex-direction: column;
 }
 body.dark .ops-modal {
   background: #251541;
@@ -433,6 +436,7 @@ body.dark .ops-modal {
   gap: 1.3em;
   align-items: center;
   margin-bottom: 1em;
+  cursor: move;
 }
 
 .modal-header img {
@@ -452,6 +456,8 @@ body.dark .ops-modal {
 .modal-content-body {
   margin-bottom: 1.1em;
   font-size: 1.05em;
+  overflow-y: auto;
+  flex-shrink: 1;
 }
 
 .modal-features {

--- a/js/main.js
+++ b/js/main.js
@@ -71,6 +71,9 @@ function createModal(serviceKey, lang) {
   modalBackdrop.appendChild(modalContent);
   modalRoot.appendChild(modalBackdrop);
 
+  // Make the modal draggable
+  makeDraggable(modalContent);
+
   // Update button text with translations
   updateModalContent(modalContent, lang);
 
@@ -105,6 +108,50 @@ function createModal(serviceKey, lang) {
 
   function closeModal() {
     modalRoot.innerHTML = '';
+  }
+}
+
+function makeDraggable(modal) {
+  const header = modal.querySelector('.modal-header');
+  if (!header) return;
+
+  let isDragging = false;
+  let offsetX, offsetY;
+
+  header.addEventListener('mousedown', (e) => {
+    isDragging = true;
+
+    // We calculate the offset from the top-left of the modal.
+    // This prevents the modal from "jumping" to the cursor position.
+    offsetX = e.clientX - modal.offsetLeft;
+    offsetY = e.clientY - modal.offsetTop;
+
+    // The transform is removed to allow for smooth dragging based on top/left.
+    modal.style.transform = 'none';
+
+    // We add the listeners to the document so that dragging continues
+    // even if the cursor moves outside the modal header.
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  });
+
+  function onMouseMove(e) {
+    if (!isDragging) return;
+
+    // Prevent text selection during drag
+    e.preventDefault();
+
+    const newX = e.clientX - offsetX;
+    const newY = e.clientY - offsetY;
+
+    modal.style.left = `${newX}px`;
+    modal.style.top = `${newY}px`;
+  }
+
+  function onMouseUp() {
+    isDragging = false;
+    document.removeEventListener('mousemove', onMouseMove);
+    document.removeEventListener('mouseup', onMouseUp);
   }
 }
 


### PR DESCRIPTION
This commit implements several improvements to the modal dialog.

- Makes the modal draggable by its header.
- Adjusts the modal width to 80vw for better responsiveness on mobile devices.
- Centers the modal on the screen.
- Constrains the modal's height and makes the content area scrollable to prevent overflow and page scrollbars.
- Updates CSS to use absolute positioning for the modal to support dragging.
- Adds a `cursor: move` style to the modal header as a visual indicator for draggability.