### PR TITLE
Refine card grid layout for wider cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -329,6 +329,7 @@ li {
   cursor: pointer;
   min-height: 170px;
   font-size: 0.93em;
+  max-width: 25rem;
 }
 
 .card:hover {
@@ -539,14 +540,14 @@ body.dark .ops-modal {
 
 @media (min-width: 1200px) {
   .grid-container {
-    grid-template-columns: repeat(4, 1fr); /* NEW: Displays four cards per row */
+    grid-template-columns: repeat(3, 1fr); /* Displays three cards per row */
   }
 }
 
 @media (min-width: 1024px) {
-  /* This rule ensures 4 cards fit horizontally on desktop screens */
+  /* This rule ensures three cards fit horizontally on desktop screens */
   .grid-container {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(3, 1fr);
   }
 }
 


### PR DESCRIPTION
## Summary
- display only three cards per row at 1024px and 1200px breakpoints
- set a max-width on cards for consistent sizing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891204c1804832b9b9ee0ed5a9dc87b