### PR TITLE
Add draggable pop-up helpers for contact, join, and chatbot

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -63,7 +63,7 @@ function createModal(serviceKey, lang) {
       <a href="${serviceData.learn}" class="modal-btn" data-key="modal-learn-more"></a>
       <a href="#" id="ask-chattia-btn" class="modal-btn" data-key="modal-ask-chattia"></a>
       <a href="#" id="join-us-btn" class="modal-btn" data-key="modal-join-us"></a>
-      <a href="contact-center.html#form" class="modal-btn" data-key="modal-contact-us"></a>
+      <a href="#" id="contact-us-btn" class="modal-btn" data-key="modal-contact-us"></a>
     </div>
   `;
 
@@ -83,17 +83,22 @@ function createModal(serviceKey, lang) {
   const askChattiaBtn = document.getElementById('ask-chattia-btn');
   askChattiaBtn.addEventListener('click', (e) => {
     e.preventDefault();
-    console.log('Redirecting to Chatbot via Cloudflare Worker...');
-    alert('Launching Chatbot...');
     closeModal();
+    openChatbotModal();
   });
 
   const joinUsBtn = document.getElementById('join-us-btn');
   joinUsBtn.addEventListener('click', (e) => {
     e.preventDefault();
-    console.log('Redirecting to Join Us form via Cloudflare Worker...');
-    alert('Launching Join Us form...');
     closeModal();
+    openJoinModal();
+  });
+
+  const contactUsBtn = document.getElementById('contact-us-btn');
+  contactUsBtn.addEventListener('click', (e) => {
+    e.preventDefault();
+    closeModal();
+    openContactModal();
   });
   
   // Add event listener to close button
@@ -176,6 +181,107 @@ function handleFormSubmit(event) {
   event.target.reset(); // Clear the form
 }
 
+// Open a contact form modal
+function openContactModal() {
+  const modalRoot = document.getElementById('modal-root');
+  const modal = document.createElement('div');
+  modal.className = 'ops-modal';
+
+  modal.innerHTML = `
+    <button class="close-modal" aria-label="Close modal">×</button>
+    <div class="modal-header"><h3 data-key="modal-contact-us">Contact Us</h3></div>
+    <div class="modal-content-body">
+      <form>
+        <input type="text" placeholder="" data-key="form-name" required />
+        <input type="email" placeholder="" data-key="form-email" required />
+        <input type="tel" placeholder="" data-key="form-phone" required />
+        <input type="text" placeholder="" data-key="form-company" required />
+        <button type="submit" class="submit-button" data-key="form-submit">Request Now</button>
+      </form>
+    </div>
+  `;
+
+  modalRoot.appendChild(modal);
+  updateModalContent(modal, currentLanguage);
+  makeDraggable(modal);
+
+  modal.querySelector('form').addEventListener('submit', handleFormSubmit);
+  modal.querySelector('.close-modal').addEventListener('click', () => {
+    modal.remove();
+  });
+}
+
+// Open a join-us form modal
+function openJoinModal() {
+  const modalRoot = document.getElementById('modal-root');
+  const modal = document.createElement('div');
+  modal.className = 'ops-modal';
+
+  modal.innerHTML = `
+    <button class="close-modal" aria-label="Close modal">×</button>
+    <div class="modal-header"><h3 data-key="modal-join-us">Join Us</h3></div>
+    <div class="modal-content-body">
+      <form>
+        <input type="text" placeholder="" data-key="form-name" required />
+        <input type="email" placeholder="" data-key="form-email" required />
+        <input type="tel" placeholder="" data-key="form-phone" required />
+        <input type="text" placeholder="" data-key="form-company" required />
+        <button type="submit" class="submit-button" data-key="form-submit">Request Now</button>
+      </form>
+    </div>
+  `;
+
+  modalRoot.appendChild(modal);
+  updateModalContent(modal, currentLanguage);
+  makeDraggable(modal);
+
+  modal.querySelector('form').addEventListener('submit', handleFormSubmit);
+  modal.querySelector('.close-modal').addEventListener('click', () => {
+    modal.remove();
+  });
+}
+
+// Open a simple chatbot modal
+function openChatbotModal() {
+  const modalRoot = document.getElementById('modal-root');
+  const modal = document.createElement('div');
+  modal.className = 'ops-modal';
+
+  modal.innerHTML = `
+    <button class="close-modal" aria-label="Close modal">×</button>
+    <div class="modal-header"><h3 data-key="modal-ask-chattia">Ask Chattia</h3></div>
+    <div class="modal-content-body chatbot-body">
+      <div class="chat-log" aria-live="polite"></div>
+      <form class="chat-form">
+        <input type="text" aria-label="Message" placeholder="Type your message" required />
+        <button type="submit">Send</button>
+      </form>
+    </div>
+  `;
+
+  modalRoot.appendChild(modal);
+  updateModalContent(modal, currentLanguage);
+  makeDraggable(modal);
+
+  modal.querySelector('.close-modal').addEventListener('click', () => {
+    modal.remove();
+  });
+
+  const chatForm = modal.querySelector('form');
+  chatForm.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const input = chatForm.querySelector('input');
+    const message = input.value.trim();
+    if (!message) return;
+    const log = modal.querySelector('.chat-log');
+    const userMsg = document.createElement('div');
+    userMsg.className = 'chat-message user';
+    userMsg.textContent = message;
+    log.appendChild(userMsg);
+    input.value = '';
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   // --- Main Page Logic ---
   // Generate service cards on the main page dynamically
@@ -197,5 +303,45 @@ document.addEventListener('DOMContentLoaded', () => {
   const forms = document.querySelectorAll('form');
   forms.forEach(form => {
     form.addEventListener('submit', handleFormSubmit);
+  });
+
+  // --- Modal trigger buttons ---
+  const contactTriggers = [
+    document.getElementById('contact-fab'),
+    document.getElementById('mobile-contact-btn')
+  ];
+  contactTriggers.forEach(btn => {
+    if (btn) {
+      btn.addEventListener('click', (e) => {
+        e.preventDefault();
+        openContactModal();
+      });
+    }
+  });
+
+  const joinTriggers = [
+    document.getElementById('join-fab'),
+    document.getElementById('mobile-join-btn')
+  ];
+  joinTriggers.forEach(btn => {
+    if (btn) {
+      btn.addEventListener('click', (e) => {
+        e.preventDefault();
+        openJoinModal();
+      });
+    }
+  });
+
+  const chatbotTriggers = [
+    document.getElementById('chatbot-fab'),
+    document.getElementById('mobile-chatbot-btn')
+  ];
+  chatbotTriggers.forEach(btn => {
+    if (btn) {
+      btn.addEventListener('click', (e) => {
+        e.preventDefault();
+        openChatbotModal();
+      });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- implement `openContactModal`, `openJoinModal`, and `openChatbotModal`
- link FAB, mobile-nav, and service modal buttons to new helpers
- add accessible close buttons and remove pop-ups on close

## Testing
- `node --check js/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68915da28d9c832ba9e12b3ee141745e