### PR TITLE
refactor: simplify modal handling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -402,16 +402,6 @@ body.dark .card .icon > i {
 }
 
 /* Modal */
-.modal-backdrop {
-  position: fixed;
-  z-index: 1999;
-  left: 0;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(44, 26, 73, 0.31);
-}
-
 .ops-modal {
   position: absolute;
   top: 50%;

--- a/js/main.js
+++ b/js/main.js
@@ -39,10 +39,7 @@ function createModal(serviceKey, lang) {
 
   if (!modalData) return;
 
-  // Create modal backdrop and content
-  const modalBackdrop = document.createElement('div');
-  modalBackdrop.className = 'modal-backdrop';
-
+  // Create modal content
   const modalContent = document.createElement('div');
   modalContent.className = 'ops-modal';
 
@@ -67,9 +64,8 @@ function createModal(serviceKey, lang) {
     </div>
   `;
 
-  // Append modal to the DOM
-  modalBackdrop.appendChild(modalContent);
-  modalRoot.appendChild(modalBackdrop);
+  // Append modal directly to the modal root
+  modalRoot.appendChild(modalContent);
 
   // Make the modal draggable
   makeDraggable(modalContent);
@@ -100,14 +96,16 @@ function createModal(serviceKey, lang) {
   modalContent.querySelector('.close-modal').addEventListener('click', closeModal);
 
   // Close modal when clicking outside of it
-  modalBackdrop.addEventListener('click', (event) => {
-    if (event.target === modalBackdrop) {
+  function handleOutsideClick(event) {
+    if (!modalContent.contains(event.target)) {
       closeModal();
     }
-  });
+  }
+  document.addEventListener('click', handleOutsideClick);
 
   function closeModal() {
     modalRoot.innerHTML = '';
+    document.removeEventListener('click', handleOutsideClick);
   }
 }
 
@@ -154,6 +152,9 @@ function makeDraggable(modal) {
     document.removeEventListener('mouseup', onMouseUp);
   }
 }
+
+// Export the draggable helper for other modules
+window.makeDraggable = makeDraggable;
 
 // Helper function to update content inside the modal after creation
 function updateModalContent(modalElement, lang) {


### PR DESCRIPTION
## Summary
- drop modal backdrop and append content directly to `#modal-root`
- close modal on outside clicks via document listener
- expose `makeDraggable` on `window` for reuse

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68915da68880832b9e6cb64a960e9319