### PR TITLE
Refactor modal handlers and apply CSP headers

### DIFF
--- a/contact-center.html
+++ b/contact-center.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://placehold.co; style-src 'self' https://cdnjs.cloudflare.com; font-src 'self' https://cdnjs.cloudflare.com; script-src 'self'; connect-src 'self'; frame-ancestors 'none';" />
   <title data-key="title-contact-center">Contact Center | Ops Online Support</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="css/style.css" />

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://placehold.co; style-src 'self' https://cdnjs.cloudflare.com; font-src 'self' https://cdnjs.cloudflare.com; script-src 'self'; connect-src 'self'; frame-ancestors 'none';" />
   <title data-key="title-business-ops">Business Operations | Ops Online Support</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="css/style.css" />

--- a/it-support.html
+++ b/it-support.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://placehold.co; style-src 'self' https://cdnjs.cloudflare.com; font-src 'self' https://cdnjs.cloudflare.com; script-src 'self'; connect-src 'self'; frame-ancestors 'none';" />
   <title data-key="title-it-support">IT Support | Ops Online Support</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="css/style.css" />

--- a/js/langtheme.js
+++ b/js/langtheme.js
@@ -201,6 +201,8 @@ const translations = {
     'modal-ask-chattia': "Ask Chattia",
     'modal-join-us': "Join Us",
     'modal-contact-us': "Contact Us",
+    'modal-chattia-loading': "Launching Chatbot...",
+    'modal-joinus-loading': "Opening Join Us form...",
   },
   es: {
     'title-business-ops': "Servicios de Gestion | Ops Online Support",
@@ -249,6 +251,8 @@ const translations = {
     'modal-ask-chattia': "Pregunta a Chattia",
     'modal-join-us': "Únete a Nosotros",
     'modal-contact-us': "Contáctanos",
+    'modal-chattia-loading': "Iniciando Chatbot...",
+    'modal-joinus-loading': "Abriendo formulario Únete a Nosotros...",
   },
 };
 

--- a/js/main.js
+++ b/js/main.js
@@ -61,8 +61,8 @@ function createModal(serviceKey, lang) {
     </div>
     <div class="modal-actions">
       <a href="${serviceData.learn}" class="modal-btn" data-key="modal-learn-more"></a>
-      <a href="#" id="ask-chattia-btn" class="modal-btn" data-key="modal-ask-chattia"></a>
-      <a href="#" id="join-us-btn" class="modal-btn" data-key="modal-join-us"></a>
+      <a href="#" id="ask-chattia-btn" class="modal-btn" data-key="modal-ask-chattia" aria-controls="chattia-modal"></a>
+      <a href="#" id="join-us-btn" class="modal-btn" data-key="modal-join-us" aria-controls="join-us-modal"></a>
       <a href="contact-center.html#form" class="modal-btn" data-key="modal-contact-us"></a>
     </div>
   `;
@@ -78,28 +78,92 @@ function createModal(serviceKey, lang) {
   updateModalContent(modalContent, lang);
 
   // Add event listeners for new buttons
-  // Note: These are placeholders. You will need to replace the `console.log` calls
-  // with actual calls to your Cloudflare Workers or other services.
   const askChattiaBtn = document.getElementById('ask-chattia-btn');
   askChattiaBtn.addEventListener('click', (e) => {
     e.preventDefault();
-    console.log('Redirecting to Chatbot via Cloudflare Worker...');
-    alert('Launching Chatbot...');
+    console.log('Opening Chatbot modal');
     closeModal();
+    openChattiaModal();
   });
 
   const joinUsBtn = document.getElementById('join-us-btn');
   joinUsBtn.addEventListener('click', (e) => {
     e.preventDefault();
-    console.log('Redirecting to Join Us form via Cloudflare Worker...');
-    alert('Launching Join Us form...');
+    console.log('Opening Join Us modal');
     closeModal();
+    openJoinUsModal();
   });
   
   // Add event listener to close button
   modalContent.querySelector('.close-modal').addEventListener('click', closeModal);
 
   // Close modal when clicking outside of it
+  modalBackdrop.addEventListener('click', (event) => {
+    if (event.target === modalBackdrop) {
+      closeModal();
+    }
+  });
+
+  function closeModal() {
+    modalRoot.innerHTML = '';
+  }
+}
+
+function openChattiaModal() {
+  const modalRoot = document.getElementById('modal-root');
+  const modalBackdrop = document.createElement('div');
+  modalBackdrop.className = 'modal-backdrop';
+
+  const modalContent = document.createElement('div');
+  modalContent.className = 'ops-modal';
+  modalContent.id = 'chattia-modal';
+  modalContent.innerHTML = `
+    <button class="close-modal" aria-label="Close modal">×</button>
+    <div class="modal-content-body">
+      <p data-key="modal-chattia-loading">Launching Chatbot...</p>
+    </div>
+  `;
+
+  modalBackdrop.appendChild(modalContent);
+  modalRoot.appendChild(modalBackdrop);
+
+  makeDraggable(modalContent);
+  updateModalContent(modalContent, currentLanguage);
+
+  modalContent.querySelector('.close-modal').addEventListener('click', closeModal);
+  modalBackdrop.addEventListener('click', (event) => {
+    if (event.target === modalBackdrop) {
+      closeModal();
+    }
+  });
+
+  function closeModal() {
+    modalRoot.innerHTML = '';
+  }
+}
+
+function openJoinUsModal() {
+  const modalRoot = document.getElementById('modal-root');
+  const modalBackdrop = document.createElement('div');
+  modalBackdrop.className = 'modal-backdrop';
+
+  const modalContent = document.createElement('div');
+  modalContent.className = 'ops-modal';
+  modalContent.id = 'join-us-modal';
+  modalContent.innerHTML = `
+    <button class="close-modal" aria-label="Close modal">×</button>
+    <div class="modal-content-body">
+      <p data-key="modal-joinus-loading">Opening Join Us form...</p>
+    </div>
+  `;
+
+  modalBackdrop.appendChild(modalContent);
+  modalRoot.appendChild(modalBackdrop);
+
+  makeDraggable(modalContent);
+  updateModalContent(modalContent, currentLanguage);
+
+  modalContent.querySelector('.close-modal').addEventListener('click', closeModal);
   modalBackdrop.addEventListener('click', (event) => {
     if (event.target === modalBackdrop) {
       closeModal();

--- a/professional-services.html
+++ b/professional-services.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://placehold.co; style-src 'self' https://cdnjs.cloudflare.com; font-src 'self' https://cdnjs.cloudflare.com; script-src 'self'; connect-src 'self'; frame-ancestors 'none';" />
   <title data-key="title-professionals">Professional Services | Ops Online Support</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="css/style.css" />


### PR DESCRIPTION
## Summary
- Replace alert-based modal buttons with functions that open dedicated Ask Chattia and Join Us modals, closing the service modal first
- Localize new modal messages and wire up aria-controls for accessibility
- Enforce a Content Security Policy across pages to curb clickjacking and XSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68915dbbcee0832bb107172fa72b7daf