### PR TITLE
feat: add contact modal

### DIFF
--- a/contact-center.html
+++ b/contact-center.html
@@ -59,6 +59,9 @@
       </form>
     </section>
   </main>
+  <button class="fab-contact" aria-label="Contact us" onclick="openContactModal()">
+    <i class="fas fa-envelope"></i>
+  </button>
   <div id="modal-root"></div>
   <script src="js/langtheme.js" defer></script>
   <script src="js/main.js" defer></script>

--- a/contactus.html
+++ b/contactus.html
@@ -1,0 +1,21 @@
+<dialog id="contact-modal">
+  <form id="contact-modal-form">
+    <h2>Contact Us</h2>
+    <label>
+      <span>Name</span>
+      <input type="text" name="name" required />
+    </label>
+    <label>
+      <span>Email</span>
+      <input type="email" name="email" required />
+    </label>
+    <label>
+      <span>Message</span>
+      <textarea name="message" required></textarea>
+    </label>
+    <menu>
+      <button type="submit" class="modal-btn">Send</button>
+      <button type="button" class="modal-btn close-modal">Cancel</button>
+    </menu>
+  </form>
+</dialog>

--- a/css/style.css
+++ b/css/style.css
@@ -593,3 +593,58 @@ body.dark .ops-modal {
   50% { background-position: 100% 50%; }
   100% { background-position: 0% 50%; }
 }
+
+/* Contact Modal and Floating Action Button */
+#contact-modal {
+  width: min(90%, 500px);
+  border: none;
+  border-radius: 8px;
+  padding: var(--space-lg) var(--space-md);
+}
+
+#contact-modal form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+#contact-modal menu {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-sm);
+  padding: 0;
+}
+
+.fab-contact {
+  position: fixed;
+  bottom: var(--space-lg);
+  right: var(--space-lg);
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  border: none;
+  background: var(--clr-primary);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+  z-index: 1000;
+}
+
+.fab-contact:focus {
+  outline: 2px solid var(--clr-accent);
+}
+
+@media (max-width: 600px) {
+  .fab-contact {
+    bottom: var(--space-md);
+    right: var(--space-md);
+    width: 48px;
+    height: 48px;
+  }
+  #contact-modal {
+    width: 95%;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -44,6 +44,9 @@
     </section>
   </main>
 
+  <button class="fab-contact" aria-label="Contact us" onclick="openContactModal()">
+    <i class="fas fa-envelope"></i>
+  </button>
   <div id="modal-root"></div>
   <script src="js/langtheme.js" defer></script>
   <script src="js/main.js" defer></script>

--- a/it-support.html
+++ b/it-support.html
@@ -58,6 +58,9 @@
       </form>
     </section>
   </main>
+  <button class="fab-contact" aria-label="Contact us" onclick="openContactModal()">
+    <i class="fas fa-envelope"></i>
+  </button>
   <div id="modal-root"></div>
   <script src="js/langtheme.js" defer></script>
   <script src="js/main.js" defer></script>

--- a/js/main.js
+++ b/js/main.js
@@ -63,7 +63,7 @@ function createModal(serviceKey, lang) {
       <a href="${serviceData.learn}" class="modal-btn" data-key="modal-learn-more"></a>
       <a href="#" id="ask-chattia-btn" class="modal-btn" data-key="modal-ask-chattia"></a>
       <a href="#" id="join-us-btn" class="modal-btn" data-key="modal-join-us"></a>
-      <a href="contact-center.html#form" class="modal-btn" data-key="modal-contact-us"></a>
+      <a href="#" id="contact-us-btn" class="modal-btn" data-key="modal-contact-us"></a>
     </div>
   `;
 
@@ -93,6 +93,13 @@ function createModal(serviceKey, lang) {
     e.preventDefault();
     console.log('Redirecting to Join Us form via Cloudflare Worker...');
     alert('Launching Join Us form...');
+    closeModal();
+  });
+
+  const contactBtn = document.getElementById('contact-us-btn');
+  contactBtn.addEventListener('click', (e) => {
+    e.preventDefault();
+    openContactModal();
     closeModal();
   });
   
@@ -167,13 +174,68 @@ function updateModalContent(modalElement, lang) {
   });
 }
 
+function sanitizeInput(str) {
+  return str.replace(/[&<>"']/g, (char) => {
+    const map = {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;'
+    };
+    return map[char];
+  });
+}
+
+async function openContactModal() {
+  let modal = document.getElementById('contact-modal');
+
+  if (!modal) {
+    const response = await fetch('contactus.html', { mode: 'same-origin' });
+    const html = await response.text();
+    const container = document.createElement('div');
+    container.innerHTML = html.trim();
+    modal = container.firstElementChild;
+    document.body.appendChild(modal);
+
+    const form = modal.querySelector('form');
+    form.addEventListener('submit', handleFormSubmit);
+    modal.querySelector('.close-modal').addEventListener('click', () => modal.close());
+  }
+
+  if (typeof modal.showModal === 'function') {
+    modal.showModal();
+  } else {
+    modal.setAttribute('open', 'true');
+  }
+}
+
 // Function to handle form submission (prevents default behavior)
-function handleFormSubmit(event) {
+async function handleFormSubmit(event) {
   event.preventDefault();
-  // In a real application, you would send this data to a server
-  console.log('Form submitted:', new FormData(event.target));
-  alert('Thank you for your submission!');
-  event.target.reset(); // Clear the form
+
+  const formData = new FormData(event.target);
+  const sanitized = {};
+  formData.forEach((value, key) => {
+    sanitized[key] = sanitizeInput(value);
+  });
+
+  try {
+    await fetch('https://example.com/api/contact', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      },
+      mode: 'cors',
+      body: JSON.stringify(sanitized)
+    });
+    alert('Thank you for your submission!');
+    event.target.reset();
+  } catch (err) {
+    console.error('Form submission failed:', err);
+    alert('Unable to submit form at this time.');
+  }
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/professional-services.html
+++ b/professional-services.html
@@ -64,6 +64,9 @@
       </form>
     </section>
   </main>
+  <button class="fab-contact" aria-label="Contact us" onclick="openContactModal()">
+    <i class="fas fa-envelope"></i>
+  </button>
   <div id="modal-root"></div>
   <script src="js/langtheme.js" defer></script>
   <script src="js/main.js" defer></script>


### PR DESCRIPTION
## Summary
- add reusable contact dialog and floating contact buttons
- wire service modals and FABs to open contact dialog
- sanitize form inputs and submit via secure HTTPS request

## Testing
- `npm test` *(fails: could not read package.json)*
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68915dce9d70832bbcf3cc36153c2cd7