### PR TITLE
Fix join modal invocation and ensure modal closure

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -156,8 +156,14 @@ function openChattiaModal() {
   }
 }
 
-function openJoinUsModal() {
+function openJoinModal() {
   const modalRoot = document.getElementById('modal-root');
+
+  // Ensure any existing modal is closed before opening a new one
+  if (modalRoot) {
+    modalRoot.innerHTML = '';
+  }
+
   const modalBackdrop = document.createElement('div');
   modalBackdrop.className = 'modal-backdrop';
 
@@ -177,16 +183,16 @@ function openJoinUsModal() {
   makeDraggable(modalContent);
   updateModalContent(modalContent, currentLanguage);
 
+  const closeModal = () => {
+    modalRoot.innerHTML = '';
+  };
+
   modalContent.querySelector('.close-modal').addEventListener('click', closeModal);
   modalBackdrop.addEventListener('click', (event) => {
     if (event.target === modalBackdrop) {
       closeModal();
     }
   });
-
-  function closeModal() {
-    modalRoot.innerHTML = '';
-  }
 }
 
 function makeDraggable(modal) {


### PR DESCRIPTION
## Summary
- rename `openJoinUsModal` to `openJoinModal`
- ensure the join modal closes any existing modal before opening

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68916a77764c832b9c2d99af83308727