### PR TITLE
fix: remove duplicate contact listener

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -95,15 +95,8 @@ function createModal(serviceKey, lang) {
   const contactBtn = document.getElementById('contact-us-btn');
   contactBtn.addEventListener('click', (e) => {
     e.preventDefault();
-    openContactModal();
     closeModal();
-  });
-
-  const contactBtn = document.getElementById('contact-us-btn');
-  contactBtn.addEventListener('click', (e) => {
-    e.preventDefault();
     openContactModal();
-    closeModal();
   });
   
   // Add event listener to close button


### PR DESCRIPTION
## Summary
- remove duplicate contact modal listener and ensure service modal closes before opening contact modal

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68916a7efce0832b9c5d20a93ba6a6dd