### PR TITLE
Remove modal backdrops from Join Us and Chattia modals

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -517,7 +517,7 @@ body.dark .card .icon > i {
   padding: 2.1rem 2.2rem 1.3rem 2.2rem;
   transition: box-shadow 0.17s;
   cursor: default;
-  z-index: 2000;
+  z-index: 3000;
   display: flex;
   flex-direction: column;
 }

--- a/joinus.html
+++ b/joinus.html
@@ -8,26 +8,24 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"/>
 </head>
 <body class="page-join-us">
-  <div id="join-modal" class="modal-backdrop">
-    <div class="ops-modal">
-      <button class="close-modal" aria-label="Close modal">×</button>
-      <div class="modal-header">
-        <h3 class="modal-title">Join Us</h3>
-      </div>
-      <div class="modal-content-body">
-        <form id="join-us-form" class="dynamic-form">
-          <input type="text" name="name" placeholder="Name" required pattern="[A-Za-z\s]+" />
-          <input type="email" name="email" placeholder="Email" required />
-          <div class="dynamic-fields">
-            <div class="field-group">
-              <input type="text" name="skills[]" placeholder="Skill" required />
-              <button type="button" class="remove-field" aria-label="Remove">&minus;</button>
-            </div>
+  <div id="join-modal" class="ops-modal">
+    <button class="close-modal" aria-label="Close modal">×</button>
+    <div class="modal-header">
+      <h3 class="modal-title">Join Us</h3>
+    </div>
+    <div class="modal-content-body">
+      <form id="join-us-form" class="dynamic-form">
+        <input type="text" name="name" placeholder="Name" required pattern="[A-Za-z\s]+" />
+        <input type="email" name="email" placeholder="Email" required />
+        <div class="dynamic-fields">
+          <div class="field-group">
+            <input type="text" name="skills[]" placeholder="Skill" required />
+            <button type="button" class="remove-field" aria-label="Remove">&minus;</button>
           </div>
-          <button type="button" class="add-field" aria-label="Add Skill">Add Skill</button>
-          <button type="submit" class="submit-button">Submit</button>
-        </form>
-      </div>
+        </div>
+        <button type="button" class="add-field" aria-label="Add Skill">Add Skill</button>
+        <button type="submit" class="submit-button">Submit</button>
+      </form>
     </div>
   </div>
 

--- a/js/main.js
+++ b/js/main.js
@@ -125,8 +125,6 @@ function createModal(serviceKey, lang) {
 
 function openChattiaModal() {
   const modalRoot = document.getElementById('modal-root');
-  const modalBackdrop = document.createElement('div');
-  modalBackdrop.className = 'modal-backdrop';
 
   const modalContent = document.createElement('div');
   modalContent.className = 'ops-modal';
@@ -138,28 +136,28 @@ function openChattiaModal() {
     </div>
   `;
 
-  modalBackdrop.appendChild(modalContent);
-  modalRoot.appendChild(modalBackdrop);
+  modalRoot.appendChild(modalContent);
 
   makeDraggable(modalContent);
   updateModalContent(modalContent, currentLanguage);
 
   modalContent.querySelector('.close-modal').addEventListener('click', closeModal);
-  modalBackdrop.addEventListener('click', (event) => {
-    if (event.target === modalBackdrop) {
+  document.addEventListener('click', handleOutsideClick);
+
+  function handleOutsideClick(event) {
+    if (!modalContent.contains(event.target)) {
       closeModal();
     }
-  });
+  }
 
   function closeModal() {
     modalRoot.innerHTML = '';
+    document.removeEventListener('click', handleOutsideClick);
   }
 }
 
 function openJoinUsModal() {
   const modalRoot = document.getElementById('modal-root');
-  const modalBackdrop = document.createElement('div');
-  modalBackdrop.className = 'modal-backdrop';
 
   const modalContent = document.createElement('div');
   modalContent.className = 'ops-modal';
@@ -171,21 +169,23 @@ function openJoinUsModal() {
     </div>
   `;
 
-  modalBackdrop.appendChild(modalContent);
-  modalRoot.appendChild(modalBackdrop);
+  modalRoot.appendChild(modalContent);
 
   makeDraggable(modalContent);
   updateModalContent(modalContent, currentLanguage);
 
   modalContent.querySelector('.close-modal').addEventListener('click', closeModal);
-  modalBackdrop.addEventListener('click', (event) => {
-    if (event.target === modalBackdrop) {
+  document.addEventListener('click', handleOutsideClick);
+
+  function handleOutsideClick(event) {
+    if (!modalContent.contains(event.target)) {
       closeModal();
     }
-  });
+  }
 
   function closeModal() {
     modalRoot.innerHTML = '';
+    document.removeEventListener('click', handleOutsideClick);
   }
 }
 


### PR DESCRIPTION
## Summary
- Drop `.modal-backdrop` wrapper from Chattia and Join Us modals
- Mount Join Us modal directly without backdrop wrapper
- Raise `.ops-modal` z-index so dialogs float above content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68916a8df290832bbc1a0541198f78e9