### PR TITLE
Add footer with copyright notice

### DIFF
--- a/contact-center.html
+++ b/contact-center.html
@@ -62,6 +62,7 @@
       </form>
     </section>
   </main>
+  <footer class="ops-footer" data-key="footer-copyright" role="contentinfo">© 2025 OPS Online Support.</footer>
   <div id="modal-root"></div>
   <script src="js/langtheme.js" defer></script>
   <script src="js/main.js" defer></script>

--- a/css/style.css
+++ b/css/style.css
@@ -208,6 +208,20 @@ li {
   background: var(--clr-accent);
 }
 
+/* Footer */
+.ops-footer {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  text-align: center;
+  padding: var(--space-sm) 0;
+  background: var(--clr-background);
+  color: var(--clr-text);
+  font-size: 0.9rem;
+  border-top: 1px solid var(--clr-form-border);
+}
+
 
 /* ==================================== */
 /* 4. Components */

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
       </form>
     </section>
   </main>
-
+  <footer class="ops-footer" data-key="footer-copyright" role="contentinfo">© 2025 OPS Online Support.</footer>
   <div id="modal-root"></div>
   <script src="js/langtheme.js" defer></script>
   <script src="js/main.js" defer></script>

--- a/it-support.html
+++ b/it-support.html
@@ -61,6 +61,7 @@
       </form>
     </section>
   </main>
+  <footer class="ops-footer" data-key="footer-copyright" role="contentinfo">© 2025 OPS Online Support.</footer>
   <div id="modal-root"></div>
   <script src="js/langtheme.js" defer></script>
   <script src="js/main.js" defer></script>

--- a/js/langtheme.js
+++ b/js/langtheme.js
@@ -198,6 +198,7 @@ const translations = {
     'cta-strategy-call': "Book Free Strategy Call",
     // Modal button
     'modal-learn-more': "Learn More",
+    'footer-copyright': '© 2025 OPS Online Support.',
   },
   es: {
     'title-business-ops': "Servicios de Gestion | Ops Online Support",
@@ -243,6 +244,7 @@ const translations = {
     'cta-strategy-call': "Reservar Llamada de Estrategia Gratis",
     // Modal button
     'modal-learn-more': "Aprende Más",
+    'footer-copyright': '© 2025 OPS Online Support.',
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "improved-fortnight",
+  "version": "1.0.0",
+  "description": "",
+  "main": "cojoinlistener.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/professional-services.html
+++ b/professional-services.html
@@ -67,6 +67,7 @@
       </form>
     </section>
   </main>
+  <footer class="ops-footer" data-key="footer-copyright" role="contentinfo">© 2025 OPS Online Support.</footer>
   <div id="modal-root"></div>
   <script src="js/langtheme.js" defer></script>
   <script src="js/main.js" defer></script>

--- a/tests/footer.test.js
+++ b/tests/footer.test.js
@@ -1,0 +1,65 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const root = path.resolve(__dirname, '..');
+const pages = ['index.html', 'contact-center.html', 'it-support.html', 'professional-services.html'];
+
+for (const page of pages) {
+  test(`footer exists in ${page}`, () => {
+    const html = fs.readFileSync(path.join(root, page), 'utf-8');
+    assert.match(html, /<footer[^>]*class="[^"]*ops-footer[^"]*"[^>]*>/);
+    assert.ok(!/<footer[^>]*hidden/.test(html));
+    assert.ok(!/<footer[^>]*style="[^"]*display:\s*none/.test(html));
+  });
+}
+
+test('footer text updates on language toggle', () => {
+  const code = fs.readFileSync(path.join(root, 'js/langtheme.js'), 'utf-8');
+
+  const footer = {
+    tagName: 'FOOTER',
+    attributes: { 'data-key': 'footer-copyright', class: 'ops-footer' },
+    style: {},
+    textContent: '',
+    getAttribute(name) { return this.attributes[name]; },
+    setAttribute(name, value) { this.attributes[name] = value; },
+    hasAttribute(name) { return Object.prototype.hasOwnProperty.call(this.attributes, name); }
+  };
+
+  const langButton = { textContent: '', setAttribute() {}, addEventListener() {} };
+
+  const document = {
+    body: { classList: { remove() {}, add() {} } },
+    querySelectorAll(selector) {
+      if (selector === '[data-key]') return [footer];
+      if (selector === '.lang-toggle') return [langButton];
+      if (selector === '.theme-toggle') return [];
+      return [];
+    },
+    addEventListener(event, cb) { if (event === 'DOMContentLoaded') cb(); }
+  };
+
+  const localStorage = {
+    store: {},
+    getItem(k) { return this.store[k]; },
+    setItem(k, v) { this.store[k] = v; }
+  };
+
+  const sandbox = { document, localStorage, console };
+  sandbox.window = sandbox;
+  vm.runInNewContext(`${code};this.exports={translations, updateContent, toggleLanguage};`, sandbox);
+
+  const { translations, updateContent, toggleLanguage } = sandbox.exports;
+
+  updateContent();
+  assert.strictEqual(footer.textContent.trim(), translations.en['footer-copyright']);
+  assert.ok(!footer.hasAttribute('hidden'));
+  assert.notStrictEqual(footer.style.display, 'none');
+
+  toggleLanguage();
+  updateContent();
+  assert.strictEqual(footer.textContent.trim(), translations.es['footer-copyright']);
+});


### PR DESCRIPTION
## Summary
- add fixed footer with 2025 OPS Online Support copyright on all main pages
- style new footer and add translation entries for language toggling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68924eab68fc832b9d7b810d6f28d07a