### PR TITLE
Restore service cards on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,27 @@
     </header>
 
     <section id="cards-section" class="grid-container">
-      </section>
+      <div class="card" data-service-key="ops">
+        <div class="title" data-key="ops-title"></div>
+        <div class="icon"><i class="fa-thin fa-briefcase"></i></div>
+        <div class="content" data-key="ops-desc"></div>
+      </div>
+      <div class="card" data-service-key="cc">
+        <div class="title" data-key="cc-title"></div>
+        <div class="icon"><i class="fa-thin fa-headset"></i></div>
+        <div class="content" data-key="cc-desc"></div>
+      </div>
+      <div class="card" data-service-key="it">
+        <div class="title" data-key="it-title"></div>
+        <div class="icon"><i class="fa-thin fa-laptop-code"></i></div>
+        <div class="content" data-key="it-desc"></div>
+      </div>
+      <div class="card" data-service-key="pro">
+        <div class="title" data-key="pro-title"></div>
+        <div class="icon"><i class="fa-thin fa-user-tie"></i></div>
+        <div class="content" data-key="pro-desc"></div>
+      </div>
+    </section>
 
   <section id="form" class="contact-form-section business-ops-form">
       <h2 data-key="form-heading">Request a Free Consultation</h2>

--- a/js/main.js
+++ b/js/main.js
@@ -1,37 +1,8 @@
 // This file contains the main logic for page-specific dynamic content and modals.
 
-// Grab the translation data from langtheme.js (which is loaded first)
+// Grab the translation data from langtheme.js (which is loaded first).
 // The `translations` object contains all service card and modal data.
 // We assume `translations` and `currentLanguage` are globally available after langtheme.js loads.
-
-
-function createServiceCards(services, lang) {
-  const container = document.getElementById('cards-section');
-  if (!container) return; // Only run this on the index page
-
-  // Clear any existing content
-  container.innerHTML = '';
-
-  Object.keys(services).forEach(key => {
-    const serviceData = services[key];
-    const cardData = serviceData[lang];
-
-    // Create a new card element
-    const card = document.createElement('div');
-    card.className = 'card';
-    card.setAttribute('data-service-key', key);
-
-    // Build the inner HTML for the card
-    card.innerHTML = `
-      <div class="title">${cardData.title}</div>
-      <div class="icon">${serviceData.icon}</div>
-      <div class="content">${cardData.desc}</div>
-    `;
-
-    // Add the card to the container
-    container.appendChild(card);
-  });
-}
 
 function createModal(serviceKey, lang) {
   const modalRoot = document.getElementById('modal-root');
@@ -193,11 +164,7 @@ async function handleFormSubmit(event) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  // --- Main Page Logic ---
-  // Generate service cards on the main page dynamically
-  createServiceCards(translations.services, currentLanguage);
-
-  // Event listener for dynamically created cards
+  // --- Card Modal Logic ---
   const cardsContainer = document.getElementById('cards-section');
   if (cardsContainer) {
     cardsContainer.addEventListener('click', (event) => {


### PR DESCRIPTION
## Summary
- Add static service cards to index page with translation hooks
- Simplify main script by removing dynamic card creation and wiring modal popups to static cards

## Testing
- `node --check js/main.js`
- `node --check js/langtheme.js`


------
https://chatgpt.com/codex/tasks/task_e_6891bba292d4832b95eeeaa37fde2799