### PR TITLE
Expose global form initializer for dynamically loaded modals

### DIFF
--- a/cojoinlistener.js
+++ b/cojoinlistener.js
@@ -98,6 +98,9 @@ document.addEventListener('DOMContentLoaded', () => {
         if (modal) {
           modal.id = `${modalId}-modal`;
           document.body.appendChild(modal);
+          if (window.initCojoinForms) {
+            window.initCojoinForms();
+          }
           modal.style.display = 'flex';
           activeModal = modal;
 

--- a/fabs/js/cojoin.js
+++ b/fabs/js/cojoin.js
@@ -6,17 +6,19 @@
  * and the dynamic form fields for the Join form.
  */
 
-document.addEventListener('DOMContentLoaded', () => {
+function initCojoinForms() {
 
   const contactForm = document.getElementById('contactForm');
   const joinForm = document.getElementById('joinForm');
 
-  if (contactForm) {
+  if (contactForm && !contactForm.dataset.cojoinInitialized) {
     contactForm.addEventListener('submit', handleContactSubmit);
+    contactForm.dataset.cojoinInitialized = 'true';
   }
 
-  if (joinForm) {
+  if (joinForm && !joinForm.dataset.cojoinInitialized) {
     joinForm.addEventListener('submit', handleJoinSubmit);
+    joinForm.dataset.cojoinInitialized = 'true';
     initJoinForm();
   }
 
@@ -281,4 +283,7 @@ document.addEventListener('DOMContentLoaded', () => {
       section.classList.remove('completed');
     }
   }
-});
+}
+
+window.initCojoinForms = initCojoinForms;
+document.addEventListener('DOMContentLoaded', initCojoinForms);


### PR DESCRIPTION
## Summary
- expose global `initCojoinForms` that binds submit listeners and prepares dynamic Join form
- invoke `initCojoinForms` after dynamically injecting a modal so forms initialize correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892530ea848832bb94ce02705fa6bfd