### PR TITLE
Fix broken image link on professional services page

### DIFF
--- a/professional-services.html
+++ b/professional-services.html
@@ -47,7 +47,7 @@
         <blockquote data-key="client-quote">“Their team didn’t just advise — they executed. We hit 120% of our revenue goal within two quarters.”</blockquote>
         <figcaption class="testimonial-author" data-key="client-author">– CEO, B2B SaaS</figcaption>
       </figure>
-      <img src="images/partner-logos.png" alt="" class="responsive-image" data-key="client-logos-alt" />
+      <img src="https://placehold.co/600x100?text=Partner+Logos" alt="" class="responsive-image" data-key="client-logos-alt" />
     </section>
 
     <section class="offer-card">


### PR DESCRIPTION
## Summary
- use hosted placeholder image for partner logos on professional services page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68925357bfe0832ba2e2c5ca4fd6450f