### PR TITLE
Add honeypots to main CTA forms

### DIFF
--- a/contact-center.html
+++ b/contact-center.html
@@ -58,6 +58,10 @@
         <input type="email" placeholder="" data-key="form-email" required />
         <input type="tel" placeholder="" data-key="form-phone" required />
         <input type="text" placeholder="" data-key="form-company" required />
+        <div class="honeypot" aria-hidden="true">
+          <label for="hp-field">Leave this field blank</label>
+          <input type="text" id="hp-field" name="hp" tabindex="-1" autocomplete="off" />
+        </div>
         <button type="submit" class="submit-button" data-key="form-submit">Request Now</button>
       </form>
     </section>

--- a/css/style.css
+++ b/css/style.css
@@ -285,6 +285,10 @@ li {
   gap: var(--space-md);
 }
 
+.honeypot {
+  display: none;
+}
+
 .contact-form-section input {
   padding: 14px 16px;
   font-size: 1rem;

--- a/index.html
+++ b/index.html
@@ -42,6 +42,10 @@
         <input type="email" placeholder="" data-key="form-email" required />
         <input type="tel" placeholder="" data-key="form-phone" required />
         <input type="text" placeholder="" data-key="form-company" required />
+        <div class="honeypot" aria-hidden="true">
+          <label for="hp-field">Leave this field blank</label>
+          <input type="text" id="hp-field" name="hp" tabindex="-1" autocomplete="off" />
+        </div>
         <button type="submit" class="submit-button" data-key="form-submit">Request Now</button>
       </form>
     </section>

--- a/it-support.html
+++ b/it-support.html
@@ -57,6 +57,10 @@
         <input type="email" placeholder="" data-key="form-email" required />
         <input type="tel" placeholder="" data-key="form-phone" required />
         <input type="text" placeholder="" data-key="form-company" required />
+        <div class="honeypot" aria-hidden="true">
+          <label for="hp-field">Leave this field blank</label>
+          <input type="text" id="hp-field" name="hp" tabindex="-1" autocomplete="off" />
+        </div>
         <button type="submit" class="submit-button" data-key="form-submit">Request Now</button>
       </form>
     </section>

--- a/js/main.js
+++ b/js/main.js
@@ -156,14 +156,24 @@ function sanitizeInput(str) {
 }
 
 // Function to handle form submission
-async function handleFormSubmit(event) {
-  event.preventDefault();
+  async function handleFormSubmit(event) {
+    event.preventDefault();
 
-  const formData = new FormData(event.target);
-  const sanitized = {};
-  formData.forEach((value, key) => {
-    sanitized[key] = sanitizeInput(value);
-  });
+    // Honeypot check: block bots that fill hidden fields
+    const honeypot = event.target.querySelector('input[name="hp"]');
+    if (honeypot && honeypot.value !== '') {
+      console.warn('Honeypot filled. Blocking form submission.');
+      event.target.reset();
+      return;
+    }
+
+    const formData = new FormData(event.target);
+    const sanitized = {};
+    formData.forEach((value, key) => {
+      if (key !== 'hp') {
+        sanitized[key] = sanitizeInput(value);
+      }
+    });
 
   try {
     await fetch('https://example.com/api/contact', {

--- a/professional-services.html
+++ b/professional-services.html
@@ -63,6 +63,10 @@
         <input type="email" placeholder="" data-key="form-email" required />
         <input type="tel" placeholder="" data-key="form-phone" required />
         <input type="text" placeholder="" data-key="form-company" required />
+        <div class="honeypot" aria-hidden="true">
+          <label for="hp-field">Leave this field blank</label>
+          <input type="text" id="hp-field" name="hp" tabindex="-1" autocomplete="off" />
+        </div>
         <button type="submit" class="submit-button" data-key="form-submit">Book Session</button>
       </form>
     </section>


### PR DESCRIPTION
## Summary
- add hidden honeypot inputs to all main page call-to-action forms
- hide honeypot fields and block submission when the field is populated

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68925533543c832b816160337912ad24