### PR TITLE
Add responsive mobile navigation menu

### DIFF
--- a/contact-center.html
+++ b/contact-center.html
@@ -13,7 +13,7 @@
 <body class="page-contact-center">
   <nav class="ops-nav">
     <div class="ops-logo">OPS</div>
-    <div class="nav-links">
+    <div class="nav-links" id="primary-nav">
       <a href="index.html" class="nav-link" data-key="nav-business-ops">Business Operations</a>
       <a href="contact-center.html" class="nav-link active" data-key="nav-contact-center">Contact Center</a>
       <a href="it-support.html" class="nav-link" data-key="nav-it-support">IT Support</a>
@@ -23,6 +23,7 @@
       <button type="button" class="toggle-btn lang-toggle" aria-label="Toggle language" aria-pressed="false">EN</button>
       <button type="button" class="toggle-btn theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
     </div>
+    <button class="nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav">Menu</button>
   </nav>
 
   <main id="page-content">

--- a/css/style.css
+++ b/css/style.css
@@ -208,6 +208,10 @@ li {
   background: var(--clr-accent);
 }
 
+.nav-menu-toggle {
+  display: none;
+}
+
 /* Footer */
 .ops-footer {
   position: fixed;
@@ -589,6 +593,37 @@ body.dark .ops-modal {
   }
   .modal-btn {
     width: 100%; /* Full width buttons on mobile */
+  }
+}
+
+@media (max-width: 768px) {
+  .ops-nav {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .toggles {
+    flex-direction: column;
+    position: static;
+    margin-bottom: 0.5rem;
+  }
+
+  .nav-links {
+    display: none;
+    width: 100%;
+  }
+
+  .nav-links.open {
+    display: flex;
+    overflow-x: auto;
+    white-space: nowrap;
+    gap: 1rem;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .nav-menu-toggle {
+    display: block;
+    margin-top: 0.5rem;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 <body class="page-business-ops">
   <nav class="ops-nav">
     <div class="ops-logo">OPS</div>
-    <div class="nav-links">
+    <div class="nav-links" id="primary-nav">
       <a href="index.html" class="nav-link active" data-key="nav-business-ops">Business Operations</a>
       <a href="contact-center.html" class="nav-link" data-key="nav-contact-center">Contact Center</a>
       <a href="it-support.html" class="nav-link" data-key="nav-it-support">IT Support</a>
@@ -23,6 +23,7 @@
       <button type="button" class="toggle-btn lang-toggle" aria-label="Toggle language" aria-pressed="false">EN</button>
       <button type="button" class="toggle-btn theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
     </div>
+    <button class="nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav">Menu</button>
   </nav>
 
   <main id="page-content">

--- a/it-support.html
+++ b/it-support.html
@@ -13,7 +13,7 @@
 <body class="page-it-support">
   <nav class="ops-nav">
     <div class="ops-logo">OPS</div>
-    <div class="nav-links">
+    <div class="nav-links" id="primary-nav">
       <a href="index.html" class="nav-link" data-key="nav-business-ops">Business Operations</a>
       <a href="contact-center.html" class="nav-link" data-key="nav-contact-center">Contact Center</a>
       <a href="it-support.html" class="nav-link active" data-key="nav-it-support">IT Support</a>
@@ -23,6 +23,7 @@
       <button type="button" class="toggle-btn lang-toggle" aria-label="Toggle language" aria-pressed="false">EN</button>
       <button type="button" class="toggle-btn theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
     </div>
+    <button class="nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav">Menu</button>
   </nav>
 
   <main id="page-content">

--- a/js/main.js
+++ b/js/main.js
@@ -191,4 +191,14 @@ document.addEventListener('DOMContentLoaded', () => {
   forms.forEach(form => {
     form.addEventListener('submit', handleFormSubmit);
   });
+
+  // --- Mobile Navigation Toggle ---
+  const navToggle = document.querySelector('.nav-menu-toggle');
+  const primaryNav = document.getElementById('primary-nav');
+  if (navToggle && primaryNav) {
+    navToggle.addEventListener('click', () => {
+      const isOpen = primaryNav.classList.toggle('open');
+      navToggle.setAttribute('aria-expanded', String(isOpen));
+    });
+  }
 });

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "test": "node --test"
   },
+  "devDependencies": {
+    "jsdom": "^24.0.0"
+  },
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/professional-services.html
+++ b/professional-services.html
@@ -13,7 +13,7 @@
 <body class="page-professional-services">
   <nav class="ops-nav">
     <div class="ops-logo">OPS</div>
-    <div class="nav-links">
+    <div class="nav-links" id="primary-nav">
       <a href="index.html" class="nav-link" data-key="nav-business-ops">Business Operations</a>
       <a href="contact-center.html" class="nav-link" data-key="nav-contact-center">Contact Center</a>
       <a href="it-support.html" class="nav-link" data-key="nav-it-support">IT Support</a>
@@ -23,6 +23,7 @@
       <button type="button" class="toggle-btn lang-toggle" aria-label="Toggle language" aria-pressed="false">EN</button>
       <button type="button" class="toggle-btn theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
     </div>
+    <button class="nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav">Menu</button>
   </nav>
 
   <main id="page-content">

--- a/tests/nav-menu.test.js
+++ b/tests/nav-menu.test.js
@@ -1,0 +1,85 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { JSDOM } = require('jsdom');
+const fs = require('fs');
+const path = require('path');
+
+// helper to load DOM with optional viewport width
+function setupDom(width = 500) {
+  const html = `<!DOCTYPE html><html><head></head><body>
+    <nav class="ops-nav">
+      <div class="nav-links" id="primary-nav">
+        <a href="#" class="nav-link">Home</a>
+        <a href="#" class="nav-link">About</a>
+      </div>
+      <div class="toggles"></div>
+      <button class="nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav">Menu</button>
+    </nav>
+  </body></html>`;
+
+  const dom = new JSDOM(html, { runScripts: 'outside-only', pretendToBeVisual: true });
+
+  // emulate viewport width and simple matchMedia
+  Object.defineProperty(dom.window, 'innerWidth', { value: width, configurable: true });
+  dom.window.matchMedia = query => ({
+    matches: width <= 768 && /max-width:\s*768px/.test(query),
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+
+  // inject CSS so computed styles are available
+  const styleEl = dom.window.document.createElement('style');
+  styleEl.textContent = fs.readFileSync(path.join(__dirname, '../css/style.css'), 'utf8');
+  dom.window.document.head.appendChild(styleEl);
+
+  // load nav script
+  const script = fs.readFileSync(path.join(__dirname, '../js/main.js'), 'utf8');
+  dom.window.eval(script);
+  dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded', { bubbles: true }));
+  return dom;
+}
+
+test('nav-menu-toggle visible and operable at mobile widths', () => {
+  const dom = setupDom(600); // below 768px
+  const doc = dom.window.document;
+  const toggle = doc.querySelector('.nav-menu-toggle');
+  const primaryNav = doc.getElementById('primary-nav');
+
+  // presence and initial attributes
+  assert.ok(toggle, 'toggle exists');
+  assert.strictEqual(toggle.getAttribute('aria-expanded'), 'false');
+  assert.notStrictEqual(dom.window.getComputedStyle(toggle).display, 'none', 'toggle visible');
+
+  // click to open
+  toggle.click();
+  assert.strictEqual(toggle.getAttribute('aria-expanded'), 'true');
+  assert.ok(primaryNav.classList.contains('open'));
+
+  // click to close again
+  toggle.click();
+  assert.strictEqual(toggle.getAttribute('aria-expanded'), 'false');
+  assert.ok(!primaryNav.classList.contains('open'));
+});
+
+test('nav-menu-toggle hidden on desktop widths', () => {
+  const dom = setupDom(1024); // above 768px
+  const doc = dom.window.document;
+  const toggle = doc.querySelector('.nav-menu-toggle');
+
+  assert.ok(toggle, 'toggle exists');
+  assert.strictEqual(dom.window.getComputedStyle(toggle).display, 'none', 'toggle hidden');
+  assert.strictEqual(toggle.getAttribute('aria-expanded'), 'false');
+});
+
+test('nav-menu-toggle CSS visibility rules', () => {
+  const css = fs.readFileSync(path.join(__dirname, '../css/style.css'), 'utf8');
+  // hidden by default
+  assert.match(css, /\.nav-menu-toggle\s*{\s*display:\s*none;\s*}/);
+  // visible within the max-width: 768px media query
+  assert.match(css, /@media\s*\(max-width:\s*768px\)[^]*?\.nav-menu-toggle\s*{[^}]*display:\s*(block|flex);?/);
+});

--- a/tests/nav-mobile.html
+++ b/tests/nav-mobile.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mobile Nav Test</title>
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <nav class="ops-nav">
+    <div class="nav-links" id="primary-nav">
+      <a href="#" class="nav-link">Home</a>
+      <a href="#" class="nav-link">About</a>
+      <a href="#" class="nav-link">Contact</a>
+    </div>
+    <div class="toggles">
+      <button type="button" class="toggle-btn lang-toggle" aria-pressed="false">EN</button>
+      <button type="button" class="toggle-btn theme-toggle" aria-pressed="false">Dark</button>
+    </div>
+    <button class="nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav">Menu</button>
+  </nav>
+
+  <script src="../js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add mobile menu button and assign `primary-nav` id on navigation links
- implement responsive styles for small screens and smooth horizontal scrolling
- toggle nav visibility with JavaScript and update `aria-expanded`
- cover mobile nav behaviour with automated tests and provide a manual demo page
- expand tests to simulate small and large viewports, asserting toggle visibility and `aria-expanded` behaviour

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jsdom)*
- `npm test` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68926e6ad74c832bb6a7dbce96fcba35