### PR TITLE
Make navigation swipeable on small screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -565,6 +565,21 @@ body.dark .ops-modal {
 }
 
 @media (max-width: 768px) {
+  /* Hide navigation links on small screens until toggled and allow
+     horizontal scrolling so users can swipe through the options */
+  .nav-links {
+    display: none;
+    flex-direction: row;
+    overflow-x: auto;
+    white-space: nowrap;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* When navigation is open, display links in a horizontal strip */
+  .nav-links.open {
+    display: flex;
+  }
+
   h1 {
     font-size: 2.2rem;
   }

--- a/tests/mobile-nav.test.js
+++ b/tests/mobile-nav.test.js
@@ -1,0 +1,53 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+
+// Helper to extract a CSS block given a selector within a media query
+function getMediaBlock(css, query) {
+  const start = css.indexOf(query);
+  if (start === -1) return '';
+  const open = css.indexOf('{', start);
+  let depth = 1;
+  let i = open + 1;
+  for (; i < css.length && depth > 0; i++) {
+    if (css[i] === '{') depth++;
+    else if (css[i] === '}') depth--;
+  }
+  return css.slice(open + 1, i - 1);
+}
+
+// Verify CSS rules for mobile navigation
+
+test('mobile nav links hidden by default and scrollable when opened', () => {
+  const css = fs.readFileSync(path.join(root, 'css', 'style.css'), 'utf-8');
+  const block = getMediaBlock(css, '@media (max-width: 768px)');
+  assert.notStrictEqual(block, '', 'mobile media query missing');
+
+  const navLinksMatch = block.match(/\.nav-links\s*{[^}]*}/);
+  assert.ok(navLinksMatch, '.nav-links rule missing');
+  const navLinks = navLinksMatch[0];
+  assert.ok(navLinks.includes('display: none'), 'nav links should be hidden by default');
+  assert.ok(navLinks.includes('flex-direction: row'), 'nav links should arrange items horizontally');
+  assert.ok(navLinks.includes('overflow-x: auto'), 'nav links should allow horizontal scrolling');
+  assert.ok(navLinks.includes('white-space: nowrap'), 'nav links should prevent wrapping');
+  assert.ok(navLinks.includes('-webkit-overflow-scrolling: touch'), 'nav links should support touch momentum scrolling');
+
+  const openMatch = block.match(/\.nav-links\.open\s*{[^}]*}/);
+  assert.ok(openMatch, '.nav-links.open rule missing');
+  const navOpen = openMatch[0];
+  assert.ok(navOpen.includes('display: flex'), 'nav links should be visible when open');
+});
+
+// Verify HTML structure defaults (nav links closed)
+const pages = ['index.html', 'contact-center.html', 'it-support.html', 'professional-services.html'];
+for (const page of pages) {
+  test(`nav links closed by default on ${page}`, () => {
+    const html = fs.readFileSync(path.join(root, page), 'utf-8');
+    assert.match(html, /<div class="nav-links">/);
+    assert.ok(!/<div class="nav-links open"/.test(html), 'nav links should not be open by default');
+  });
+}
+


### PR DESCRIPTION
## Summary
- Hide nav links by default on screens up to 768px and enable horizontal scrolling
- Keep `nav-links.open` displayed to allow swipeable navigation strip
- Document behavior with comments in mobile CSS
- Add tests ensuring nav links remain hidden until opened and form a scrollable row on mobile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68926f1c799c832bafbb25dc3664b12c