### PR TITLE
Improve mobile nav toggle alignment and menu styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -210,6 +210,20 @@ li {
 
 .nav-menu-toggle {
   display: none;
+  background: var(--clr-primary);
+  border: none;
+  color: #fff;
+  border-radius: 5px;
+  padding: 0.36em 0.86em;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background 0.18s;
+}
+
+.nav-menu-toggle:hover,
+.nav-menu-toggle:focus {
+  background: var(--clr-accent);
+  outline: none;
 }
 
 /* Footer */
@@ -568,28 +582,6 @@ body.dark .ops-modal {
   }
 }
 
-@media (max-width: 768px) {
-  .ops-nav {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-  h1 {
-    font-size: 2.2rem;
-  }
-  .cta-button.it-and-contact {
-    padding: 14px 30px;
-    font-size: 1.1rem;
-  }
-  .contact-form-section {
-    padding: 0 15px;
-    max-width: 100%;
-  }
-  .toggles {
-    position: static;
-    margin-top: var(--space-sm);
-  }
-}
-
 @media (max-width: 500px) {
   .grid-container {
     grid-template-columns: 1fr; /* Stack cards on very small screens */
@@ -610,23 +602,49 @@ body.dark .ops-modal {
     align-items: flex-start;
   }
 
+  h1 {
+    font-size: 2.2rem;
+  }
+
+  .cta-button.it-and-contact {
+    padding: 14px 30px;
+    font-size: 1.1rem;
+  }
+
+  .contact-form-section {
+    padding: 0 15px;
+    max-width: 100%;
+  }
+
   .toggles {
     flex-direction: column;
     position: static;
     margin-bottom: 0.5rem;
+    align-self: flex-end;
+    align-items: flex-end;
   }
 
   .nav-links {
     display: none;
+    flex-direction: column;
     width: 100%;
+    margin-top: 0.5rem;
+    background: var(--clr-background);
+    border: 1px solid var(--clr-form-border);
+    border-radius: 5px;
   }
 
   .nav-links.open {
     display: flex;
-    overflow-x: auto;
-    white-space: nowrap;
-    gap: 1rem;
-    -webkit-overflow-scrolling: touch;
+  }
+
+  .nav-link {
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--clr-form-border);
+  }
+
+  .nav-link:last-child {
+    border-bottom: none;
   }
 
   .nav-menu-toggle {

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
     <div class="toggles">
       <button type="button" class="toggle-btn lang-toggle" aria-label="Toggle language" aria-pressed="false">EN</button>
       <button type="button" class="toggle-btn theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
+    </div>
     <button class="nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav">Menu</button>
   </nav>
 

--- a/js/main.js
+++ b/js/main.js
@@ -176,6 +176,13 @@ function sanitizeInput(str) {
 document.addEventListener('DOMContentLoaded', () => {
   const navToggle = document.querySelector('.nav-menu-toggle');
   const navLinks = document.getElementById('primary-nav');
+  if (navToggle) {
+    const updateToggleVisibility = () => {
+      navToggle.style.display = window.innerWidth <= 768 ? 'block' : 'none';
+    };
+    updateToggleVisibility();
+    window.addEventListener('resize', updateToggleVisibility);
+  }
   if (navToggle && navLinks) {
     navToggle.addEventListener('click', () => {
       const expanded = navToggle.getAttribute('aria-expanded') === 'true';
@@ -210,13 +217,4 @@ document.addEventListener('DOMContentLoaded', () => {
     form.addEventListener('submit', handleFormSubmit);
   });
 
-  // --- Mobile Navigation Toggle ---
-  const navToggle = document.querySelector('.nav-menu-toggle');
-  const primaryNav = document.getElementById('primary-nav');
-  if (navToggle && primaryNav) {
-    navToggle.addEventListener('click', () => {
-      const isOpen = primaryNav.classList.toggle('open');
-      navToggle.setAttribute('aria-expanded', String(isOpen));
-    });
-  }
 });

--- a/tests/nav-menu.test.js
+++ b/tests/nav-menu.test.js
@@ -79,7 +79,7 @@ test('nav-menu-toggle hidden on desktop widths', () => {
 test('nav-menu-toggle CSS visibility rules', () => {
   const css = fs.readFileSync(path.join(__dirname, '../css/style.css'), 'utf8');
   // hidden by default
-  assert.match(css, /\.nav-menu-toggle\s*{\s*display:\s*none;\s*}/);
+  assert.match(css, /\.nav-menu-toggle\s*{[^}]*display:\s*none;[^}]*}/);
   // visible within the max-width: 768px media query
   assert.match(css, /@media\s*\(max-width:\s*768px\)[^]*?\.nav-menu-toggle\s*{[^}]*display:\s*(block|flex);?/);
 });


### PR DESCRIPTION
## Summary
- Align language and theme toggle buttons to the right on small screens
- Style mobile menu button with app colors and display nav links as accordion
- Adjust nav-menu tests for updated CSS and add JS fallback for menu visibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689324097714832b85c9115725013e1a