### PR TITLE
Add asset reference and DOM helper tests

### DIFF
--- a/professional-services.html
+++ b/professional-services.html
@@ -50,7 +50,7 @@
         <blockquote data-key="client-quote">“Their team didn’t just advise — they executed. We hit 120% of our revenue goal within two quarters.”</blockquote>
         <figcaption class="testimonial-author" data-key="client-author">– CEO, B2B SaaS</figcaption>
       </figure>
-      <img src="https://placehold.co/600x100?text=Partner+Logos" alt="" class="responsive-image" data-key="client-logos-alt" />
+      <img src="https://placehold.co/600x100?text=Partner+Logos" alt="Partner logos" class="responsive-image" data-key="client-logos-alt" />
     </section>
 
     <section class="offer-card">

--- a/tests/assets-functions.test.js
+++ b/tests/assets-functions.test.js
@@ -1,0 +1,99 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const root = path.resolve(__dirname, '..');
+const htmlFiles = fs.readdirSync(root).filter(f => f.endsWith('.html'));
+
+for (const page of htmlFiles) {
+  test(`assets referenced in ${page} exist and images have alt text`, () => {
+    const htmlPath = path.join(root, page);
+    const html = fs.readFileSync(htmlPath, 'utf-8');
+    const dir = path.dirname(htmlPath);
+
+    const imgRegex = /<img\b([^>]*)>/gi;
+    let imgMatch;
+    while ((imgMatch = imgRegex.exec(html))) {
+      const attrs = imgMatch[1];
+      const srcMatch = attrs.match(/src\s*=\s*"([^"]+)"/i);
+      if (srcMatch) {
+        const src = srcMatch[1];
+        if (!/^https?:\/\//i.test(src)) {
+          const filePath = path.resolve(dir, src);
+          assert.ok(fs.existsSync(filePath), `Image file not found: ${src}`);
+        }
+      }
+      const altMatch = attrs.match(/alt\s*=\s*"([^"]*)"/i);
+      assert.ok(altMatch && altMatch[1].trim().length > 0, 'Image tag missing alt text');
+    }
+
+    const scriptRegex = /<script\b[^>]*src="([^"]+)"[^>]*>/gi;
+    let scriptMatch;
+    while ((scriptMatch = scriptRegex.exec(html))) {
+      const src = scriptMatch[1];
+      if (!/^https?:\/\//i.test(src)) {
+        const filePath = path.resolve(dir, src);
+        assert.ok(fs.existsSync(filePath), `Script file not found: ${src}`);
+      }
+    }
+  });
+}
+
+function createDocumentStub() {
+  const events = {};
+  return {
+    createElement() {
+      let text = '';
+      return {
+        style: {},
+        set textContent(v) { text = v.replace(/<[^>]*>/g, ''); },
+        get textContent() { return text; },
+        appendChild() {},
+        querySelector() { return null; }
+      };
+    },
+    getElementById() { return null; },
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+    addEventListener(type, handler) { events[type] = handler; },
+    removeEventListener(type, handler) {
+      if (events[type] === handler) delete events[type];
+    },
+    _events: events
+  };
+}
+
+const code = fs.readFileSync(path.join(root, 'js/main.js'), 'utf-8');
+const documentStub = createDocumentStub();
+const sandbox = { window: { innerWidth: 1024 }, document: documentStub, console };
+vm.createContext(sandbox);
+vm.runInContext(code, sandbox);
+const { sanitizeInput, makeDraggable } = sandbox;
+
+test('sanitizeInput strips markup', () => {
+  assert.strictEqual(sanitizeInput('<b>hi</b>'), 'hi');
+});
+
+test('makeDraggable updates modal position on drag', () => {
+  const header = { events: {}, addEventListener(type, handler) { this.events[type] = handler; } };
+  const modal = {
+    offsetLeft: 0,
+    offsetTop: 0,
+    style: {},
+    querySelector(sel) { return sel === '.modal-header' ? header : null; }
+  };
+
+  makeDraggable(modal);
+  assert.strictEqual(typeof header.events.mousedown, 'function');
+
+  header.events.mousedown({ clientX: 10, clientY: 10 });
+  documentStub._events.mousemove({ clientX: 30, clientY: 40, preventDefault() {} });
+  assert.strictEqual(modal.style.transform, 'none');
+  assert.strictEqual(modal.style.left, '20px');
+  assert.strictEqual(modal.style.top, '30px');
+
+  documentStub._events.mouseup();
+  assert.ok(!documentStub._events.mousemove);
+});


### PR DESCRIPTION
## Summary
- test HTML pages for missing assets and <img> alt text
- stub DOM to unit test sanitizeInput and makeDraggable helpers
- provide alt text for partner logos image

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892f55307f4832baf7976b4b268e958