### PR TITLE
Restrict card modal activation to learn-more button

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -203,7 +203,13 @@ document.addEventListener('DOMContentLoaded', () => {
   const cardsContainer = document.getElementById('cards-section');
   if (cardsContainer) {
     cardsContainer.addEventListener('click', (event) => {
-      const card = event.target.closest('.card');
+      const learnMore = event.target.closest('.learn-more');
+      if (!learnMore) return;
+
+      // prevent the card click handler from firing when navigating
+      event.stopPropagation();
+
+      const card = learnMore.closest('.card');
       if (card) {
         const serviceKey = card.getAttribute('data-service-key');
         createModal(serviceKey, currentLanguage);

--- a/tests/cards-learn-more.test.js
+++ b/tests/cards-learn-more.test.js
@@ -1,0 +1,43 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { JSDOM } = require('jsdom');
+const fs = require('fs');
+const path = require('path');
+
+test('only .learn-more clicks open service modal', () => {
+  const html = `<!DOCTYPE html><html><body>
+    <div id="modal-root"></div>
+    <section id="cards-section">
+      <div class="card" data-service-key="ops">
+        <button class="learn-more">Learn More</button>
+      </div>
+    </section>
+  </body></html>`;
+
+  const dom = new JSDOM(html, { runScripts: 'outside-only', pretendToBeVisual: true });
+  const { window } = dom;
+  window.currentLanguage = 'en';
+
+  const script = fs.readFileSync(path.join(__dirname, '../js/main.js'), 'utf8');
+  window.eval(script);
+
+  let called = false;
+  window.createModal = () => { called = true; };
+
+  window.document.dispatchEvent(new window.Event('DOMContentLoaded', { bubbles: true }));
+
+  // click on card itself - should not open modal
+  const card = window.document.querySelector('.card');
+  called = false;
+  card.click();
+  assert.equal(called, false, 'card click should not open modal');
+
+  // click on learn-more button - should open modal and stop bubbling
+  const btn = window.document.querySelector('.learn-more');
+  let bubbled = false;
+  window.document.addEventListener('click', () => { bubbled = true; });
+  called = false;
+  btn.click();
+  assert.equal(called, true, 'learn-more click should open modal');
+  assert.equal(bubbled, false, 'event propagation should stop at container');
+});

--- a/tests/mobile-nav.test.js
+++ b/tests/mobile-nav.test.js
@@ -46,7 +46,8 @@ const pages = ['index.html', 'contact-center.html', 'it-support.html', 'professi
 for (const page of pages) {
   test(`nav links closed by default on ${page}`, () => {
     const html = fs.readFileSync(path.join(root, page), 'utf-8');
-    assert.match(html, /<div class="nav-links">/);
+    // allow additional attributes (e.g., id="primary-nav") after the class
+    assert.match(html, /<div class="nav-links"[^>]*>/);
     assert.ok(!/<div class="nav-links open"/.test(html), 'nav links should not be open by default');
   });
 }


### PR DESCRIPTION
## Summary
- limit service-card modal opening to explicit `.learn-more` button clicks and stop event propagation
- broaden mobile-nav tests to allow additional attributes on nav link container
- add regression test ensuring cards only trigger modals via `.learn-more`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68941bcfe87c832ba7fb6e3a082264f9