### PR TITLE
Add learn more buttons to service cards

### DIFF
--- a/contact-center.html
+++ b/contact-center.html
@@ -13,7 +13,7 @@
 <body class="page-contact-center">
   <nav class="ops-nav">
     <div class="ops-logo">OPS</div>
-    <div class="nav-links" id="primary-nav">
+    <div class="nav-links">
       <a href="index.html" class="nav-link" data-key="nav-business-ops">Business Operations</a>
       <a href="contact-center.html" class="nav-link active" data-key="nav-contact-center">Contact Center</a>
       <a href="it-support.html" class="nav-link" data-key="nav-it-support">IT Support</a>
@@ -23,7 +23,7 @@
       <button type="button" class="toggle-btn lang-toggle" aria-label="Toggle language" aria-pressed="false">EN</button>
       <button type="button" class="toggle-btn theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
     </div>
-    <button class="nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav">Menu</button>
+    <button class="nav-menu-toggle" aria-expanded="false">Menu</button>
   </nav>
 
   <main id="page-content">

--- a/css/style.css
+++ b/css/style.css
@@ -364,7 +364,6 @@ li {
   transition: transform 0.18s, box-shadow 0.18s;
   position: relative;
   overflow: hidden;
-  cursor: pointer;
   min-height: 170px;
   font-size: 0.93em;
   max-width: 25rem;
@@ -402,6 +401,15 @@ li {
 .card .content {
   grid-area: content;
   margin-top: 0.6rem;
+}
+
+.card .learn-more {
+  display: inline-block;
+  margin-top: 0.6rem;
+  font-weight: 600;
+  text-decoration: underline;
+  color: var(--clr-text);
+  cursor: pointer;
 }
 
 .card::after {

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 <body class="page-business-ops">
   <nav class="ops-nav">
     <div class="ops-logo">OPS</div>
-    <div class="nav-links" id="primary-nav">
+    <div class="nav-links">
       <a href="index.html" class="nav-link active" data-key="nav-business-ops">Business Operations</a>
       <a href="contact-center.html" class="nav-link" data-key="nav-contact-center">Contact Center</a>
       <a href="it-support.html" class="nav-link" data-key="nav-it-support">IT Support</a>
@@ -23,7 +23,7 @@
       <button type="button" class="toggle-btn lang-toggle" aria-label="Toggle language" aria-pressed="false">EN</button>
       <button type="button" class="toggle-btn theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
     </div>
-    <button class="nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav">Menu</button>
+    <button class="nav-menu-toggle" aria-expanded="false">Menu</button>
   </nav>
 
   <main id="page-content">
@@ -38,21 +38,25 @@
         <div class="title" data-key="ops-title"></div>
         <div class="icon"><i class="fa-thin fa-briefcase"></i></div>
         <div class="content" data-key="ops-desc"></div>
+        <a class="learn-more" data-key="modal-learn-more"></a>
       </div>
       <div class="card" data-service-key="cc">
         <div class="title" data-key="cc-title"></div>
         <div class="icon"><i class="fa-thin fa-headset"></i></div>
         <div class="content" data-key="cc-desc"></div>
+        <a class="learn-more" data-key="modal-learn-more"></a>
       </div>
       <div class="card" data-service-key="it">
         <div class="title" data-key="it-title"></div>
         <div class="icon"><i class="fa-thin fa-laptop-code"></i></div>
         <div class="content" data-key="it-desc"></div>
+        <a class="learn-more" data-key="modal-learn-more"></a>
       </div>
       <div class="card" data-service-key="pro">
         <div class="title" data-key="pro-title"></div>
         <div class="icon"><i class="fa-thin fa-user-tie"></i></div>
         <div class="content" data-key="pro-desc"></div>
+        <a class="learn-more" data-key="modal-learn-more"></a>
       </div>
     </section>
 

--- a/it-support.html
+++ b/it-support.html
@@ -13,7 +13,7 @@
 <body class="page-it-support">
   <nav class="ops-nav">
     <div class="ops-logo">OPS</div>
-    <div class="nav-links" id="primary-nav">
+    <div class="nav-links">
       <a href="index.html" class="nav-link" data-key="nav-business-ops">Business Operations</a>
       <a href="contact-center.html" class="nav-link" data-key="nav-contact-center">Contact Center</a>
       <a href="it-support.html" class="nav-link active" data-key="nav-it-support">IT Support</a>
@@ -23,7 +23,7 @@
       <button type="button" class="toggle-btn lang-toggle" aria-label="Toggle language" aria-pressed="false">EN</button>
       <button type="button" class="toggle-btn theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
     </div>
-    <button class="nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav">Menu</button>
+    <button class="nav-menu-toggle" aria-expanded="false">Menu</button>
   </nav>
 
   <main id="page-content">

--- a/js/main.js
+++ b/js/main.js
@@ -175,7 +175,7 @@ function sanitizeInput(str) {
 
 document.addEventListener('DOMContentLoaded', () => {
   const navToggle = document.querySelector('.nav-menu-toggle');
-  const navLinks = document.getElementById('primary-nav');
+  const navLinks = document.querySelector('.nav-links');
   if (navToggle) {
     const updateToggleVisibility = () => {
       navToggle.style.display = window.innerWidth <= 768 ? 'block' : 'none';
@@ -199,17 +199,25 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     });
   }
-  // --- Card Modal Logic ---
-  const cardsContainer = document.getElementById('cards-section');
-  if (cardsContainer) {
-    cardsContainer.addEventListener('click', (event) => {
-      const card = event.target.closest('.card');
-      if (card) {
-        const serviceKey = card.getAttribute('data-service-key');
-        createModal(serviceKey, currentLanguage);
+  // --- Card Learn More Buttons ---
+  const learnButtons = document.querySelectorAll('#cards-section .card .learn-more');
+  learnButtons.forEach(btn => {
+    const card = btn.closest('.card');
+    if (!card) return;
+    const serviceKey = card.getAttribute('data-service-key');
+    const serviceData = translations.services[serviceKey];
+    if (serviceData && serviceData.learn) {
+      btn.setAttribute('href', serviceData.learn);
+    }
+    btn.addEventListener('click', (event) => {
+      // Allow default behavior for modified clicks (new tab, etc.)
+      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+        return;
       }
+      event.preventDefault();
+      createModal(serviceKey, currentLanguage);
     });
-  }
+  });
 
   // --- Form Submission Logic ---
   const forms = document.querySelectorAll('form');

--- a/professional-services.html
+++ b/professional-services.html
@@ -13,7 +13,7 @@
 <body class="page-professional-services">
   <nav class="ops-nav">
     <div class="ops-logo">OPS</div>
-    <div class="nav-links" id="primary-nav">
+    <div class="nav-links">
       <a href="index.html" class="nav-link" data-key="nav-business-ops">Business Operations</a>
       <a href="contact-center.html" class="nav-link" data-key="nav-contact-center">Contact Center</a>
       <a href="it-support.html" class="nav-link" data-key="nav-it-support">IT Support</a>
@@ -23,7 +23,7 @@
       <button type="button" class="toggle-btn lang-toggle" aria-label="Toggle language" aria-pressed="false">EN</button>
       <button type="button" class="toggle-btn theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
     </div>
-    <button class="nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav">Menu</button>
+    <button class="nav-menu-toggle" aria-expanded="false">Menu</button>
   </nav>
 
   <main id="page-content">


### PR DESCRIPTION
## Summary
- add explicit `Learn More` links inside each service card and populate them from translations
- move modal trigger to the new links and update navigation code to use class selectors
- style the `Learn More` buttons for accessibility and remove pointer cursor from cards

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68941bde2504832bad831a36c5ec8979