### PR TITLE
Move menu toggle inside nav toggle group

### DIFF
--- a/contact-center.html
+++ b/contact-center.html
@@ -22,8 +22,8 @@
     <div class="toggles">
       <button type="button" class="toggle-btn lang-toggle" aria-label="Toggle language" aria-pressed="false">EN</button>
       <button type="button" class="toggle-btn theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
+      <button type="button" class="toggle-btn nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav">Menu</button>
     </div>
-    <button class="nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav">Menu</button>
   </nav>
 
   <main id="page-content">

--- a/index.html
+++ b/index.html
@@ -22,8 +22,8 @@
     <div class="toggles">
       <button type="button" class="toggle-btn lang-toggle" aria-label="Toggle language" aria-pressed="false">EN</button>
       <button type="button" class="toggle-btn theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
+      <button type="button" class="toggle-btn nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav">Menu</button>
     </div>
-    <button class="nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav">Menu</button>
   </nav>
 
   <main id="page-content">

--- a/it-support.html
+++ b/it-support.html
@@ -22,8 +22,8 @@
     <div class="toggles">
       <button type="button" class="toggle-btn lang-toggle" aria-label="Toggle language" aria-pressed="false">EN</button>
       <button type="button" class="toggle-btn theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
+      <button type="button" class="toggle-btn nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav">Menu</button>
     </div>
-    <button class="nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav">Menu</button>
   </nav>
 
   <main id="page-content">

--- a/professional-services.html
+++ b/professional-services.html
@@ -22,8 +22,8 @@
     <div class="toggles">
       <button type="button" class="toggle-btn lang-toggle" aria-label="Toggle language" aria-pressed="false">EN</button>
       <button type="button" class="toggle-btn theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
+      <button type="button" class="toggle-btn nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav">Menu</button>
     </div>
-    <button class="nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav">Menu</button>
   </nav>
 
   <main id="page-content">

--- a/tests/mobile-nav.test.js
+++ b/tests/mobile-nav.test.js
@@ -46,7 +46,7 @@ const pages = ['index.html', 'contact-center.html', 'it-support.html', 'professi
 for (const page of pages) {
   test(`nav links closed by default on ${page}`, () => {
     const html = fs.readFileSync(path.join(root, page), 'utf-8');
-    assert.match(html, /<div class="nav-links">/);
+    assert.match(html, /<div class="nav-links"/);
     assert.ok(!/<div class="nav-links open"/.test(html), 'nav links should not be open by default');
   });
 }


### PR DESCRIPTION
## Summary
- group navigation menu toggle with other nav toggles for consistent order and styling
- loosen mobile nav test regex to accommodate additional attributes on nav container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68941bfd5d8c832bb71c3d28ffcb3465