### PR TITLE
feat: add off-canvas nav and focus trap

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -658,17 +658,26 @@ body.dark .ops-modal {
   }
 
   .nav-links {
-    display: none;
+    position: fixed;
+    top: 0;
+    right: 0;
+    height: 100%;
+    width: 70%;
+    max-width: 300px;
+    display: flex;
     flex-direction: column;
-    width: 100%;
-    margin-top: 0.5rem;
+    margin-top: 0;
     background: var(--clr-background);
-    border: 1px solid var(--clr-form-border);
-    border-radius: 5px;
+    border-left: 1px solid var(--clr-form-border);
+    border-radius: 5px 0 0 5px;
+    transform: translateX(100%);
+    transition: transform 0.3s ease;
+    padding: var(--space-xl) var(--space-md);
+    z-index: 1000;
   }
 
   .nav-links.open {
-    display: flex;
+    transform: translateX(0);
   }
 
   .nav-link {

--- a/js/main.js
+++ b/js/main.js
@@ -184,17 +184,63 @@ document.addEventListener('DOMContentLoaded', () => {
     window.addEventListener('resize', updateToggleVisibility);
   }
   if (navToggle && navLinks) {
+    let lastFocusedElement;
+    let firstFocusable;
+    let lastFocusable;
+
+    function trapFocus(e) {
+      if (e.key === 'Tab') {
+        if (e.shiftKey) {
+          if (document.activeElement === firstFocusable) {
+            e.preventDefault();
+            lastFocusable.focus();
+          }
+        } else {
+          if (document.activeElement === lastFocusable) {
+            e.preventDefault();
+            firstFocusable.focus();
+          }
+        }
+      } else if (e.key === 'Escape') {
+        closeMenu();
+      }
+    }
+
+    function openMenu() {
+      navLinks.classList.add('open');
+      navToggle.setAttribute('aria-expanded', 'true');
+      const focusable = navLinks.querySelectorAll('a, button');
+      firstFocusable = focusable[0];
+      lastFocusable = focusable[focusable.length - 1];
+      lastFocusedElement = document.activeElement;
+      if (firstFocusable) {
+        firstFocusable.focus();
+      }
+      document.addEventListener('keydown', trapFocus);
+    }
+
+    function closeMenu() {
+      navLinks.classList.remove('open');
+      navToggle.setAttribute('aria-expanded', 'false');
+      document.removeEventListener('keydown', trapFocus);
+      if (lastFocusedElement) {
+        lastFocusedElement.focus();
+      }
+    }
+
     navToggle.addEventListener('click', () => {
-      const expanded = navToggle.getAttribute('aria-expanded') === 'true';
-      navToggle.setAttribute('aria-expanded', String(!expanded));
-      navLinks.classList.toggle('open');
+      const isOpen = navLinks.classList.contains('open');
+      if (isOpen) {
+        closeMenu();
+      } else {
+        openMenu();
+      }
     });
 
     navLinks.querySelectorAll('a').forEach(link => {
       link.addEventListener('click', () => {
         if (window.innerWidth <= 768) {
-          navLinks.classList.remove('open');
-          navToggle.setAttribute('aria-expanded', 'false');
+          closeMenu();
         }
       });
     });

--- a/tests/mobile-nav.test.js
+++ b/tests/mobile-nav.test.js
@@ -21,24 +21,17 @@ function getMediaBlock(css, query) {
 
 // Verify CSS rules for mobile navigation
 
-test('mobile nav links hidden by default and scrollable when opened', () => {
+test('mobile nav links use off-canvas layout', () => {
   const css = fs.readFileSync(path.join(root, 'css', 'style.css'), 'utf-8');
-  const block = getMediaBlock(css, '@media (max-width: 768px)');
-  assert.notStrictEqual(block, '', 'mobile media query missing');
+  const offCanvasMatch = css.match(/@media \(max-width: 768px\)[\s\S]*?\.nav-links\s*{[\s\S]*?position: fixed[\s\S]*?}/);
+  assert.ok(offCanvasMatch, 'nav links should be positioned off-canvas');
+  const navLinks = offCanvasMatch[0];
+  assert.ok(navLinks.includes('right: 0'), 'nav links should align to the right');
+  assert.ok(navLinks.includes('transform: translateX(100%)'), 'nav links should be translated off screen');
+  assert.ok(navLinks.includes('transition: transform 0.3s'), 'nav links should animate when toggled');
 
-  const navLinksMatch = block.match(/\.nav-links\s*{[^}]*}/);
-  assert.ok(navLinksMatch, '.nav-links rule missing');
-  const navLinks = navLinksMatch[0];
-  assert.ok(navLinks.includes('display: none'), 'nav links should be hidden by default');
-  assert.ok(navLinks.includes('flex-direction: row'), 'nav links should arrange items horizontally');
-  assert.ok(navLinks.includes('overflow-x: auto'), 'nav links should allow horizontal scrolling');
-  assert.ok(navLinks.includes('white-space: nowrap'), 'nav links should prevent wrapping');
-  assert.ok(navLinks.includes('-webkit-overflow-scrolling: touch'), 'nav links should support touch momentum scrolling');
-
-  const openMatch = block.match(/\.nav-links\.open\s*{[^}]*}/);
-  assert.ok(openMatch, '.nav-links.open rule missing');
-  const navOpen = openMatch[0];
-  assert.ok(navOpen.includes('display: flex'), 'nav links should be visible when open');
+  const openMatch = css.match(/@media \(max-width: 768px\)[\s\S]*?\.nav-links\.open\s*{[\s\S]*?transform: translateX\(0\)[^}]*}/);
+  assert.ok(openMatch, 'nav links should slide in when open');
 });
 
 // Verify HTML structure defaults (nav links closed)
@@ -46,7 +39,7 @@ const pages = ['index.html', 'contact-center.html', 'it-support.html', 'professi
 for (const page of pages) {
   test(`nav links closed by default on ${page}`, () => {
     const html = fs.readFileSync(path.join(root, page), 'utf-8');
-    assert.match(html, /<div class="nav-links">/);
+    assert.match(html, /<div class="nav-links"[^>]*>/);
     assert.ok(!/<div class="nav-links open"/.test(html), 'nav links should not be open by default');
   });
 }


### PR DESCRIPTION
## Summary
- implement off-canvas mobile navigation menu and sliding animation
- trap focus within open menu for accessible keyboard navigation
- adjust mobile nav tests for new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68941c0d9e18832bb1875fbabc73bc68