### PR TITLE
feat: improve accessibility labels and focus styles

### DIFF
--- a/contact-center.html
+++ b/contact-center.html
@@ -30,7 +30,7 @@
     <header>
       <h1 data-key="header-heading">Connect with Your Customers.</h1>
       <p data-key="header-subheading">Enhance customer engagement with multilingual, multichannel support—24/7, data-driven, and empathetic.</p>
-      <a href="#form" class="cta-button it-and-contact" data-key="cta-learn-more">Learn More</a>
+      <a href="#form" class="cta-button it-and-contact learn-more" data-key="cta-learn-more">Learn More</a>
     </header>
 
     <section>

--- a/css/style.css
+++ b/css/style.css
@@ -546,6 +546,11 @@ body.dark .ops-modal {
   outline: none;
 }
 
+.learn-more:focus {
+  outline: 2px solid var(--clr-primary);
+  outline-offset: 2px;
+}
+
 .modal-btn.cta:hover {
   background: linear-gradient(90deg, var(--clr-accent), var(--clr-primary));
 }

--- a/index.html
+++ b/index.html
@@ -20,17 +20,17 @@
       <a href="professional-services.html" class="nav-link" data-key="nav-professionals">Professionals</a>
     </div>
     <div class="toggles">
-      <button type="button" class="toggle-btn lang-toggle" aria-label="Toggle language" aria-pressed="false">EN</button>
-      <button type="button" class="toggle-btn theme-toggle" aria-label="Toggle theme" aria-pressed="false">Dark</button>
+      <button type="button" class="toggle-btn lang-toggle" aria-pressed="false" aria-label="" data-aria-label-key="aria-toggle-language">EN</button>
+      <button type="button" class="toggle-btn theme-toggle" aria-pressed="false" aria-label="" data-aria-label-key="aria-toggle-theme">Dark</button>
     </div>
-    <button class="nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav">Menu</button>
+    <button class="nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav" data-key="nav-menu" aria-label="" data-aria-label-key="aria-nav-menu">Menu</button>
   </nav>
 
   <main id="page-content">
     <header>
       <h1 data-key="header-heading">Empower Your Business. Simplify Your Life.</h1>
       <p data-key="header-subheading">From operational efficiency to expert staffing, we've got your back. </p>
-      <a href="#cards-section" class="cta-button business-ops" data-key="cta-explore">Explore Services</a>
+      <a href="#cards-section" class="cta-button business-ops" data-key="cta-explore" aria-label="" data-aria-label-key="aria-cta-explore">Explore Services</a>
     </header>
 
     <section id="cards-section" class="grid-container">

--- a/it-support.html
+++ b/it-support.html
@@ -30,7 +30,7 @@
     <header>
       <h1 data-key="header-heading">Keep Your Systems Secure and Stable</h1>
       <p data-key="header-subheading">Dependable help desk, cybersecurity, and cloud services to keep your IT infrastructure running smoothly.</p>
-      <a href="#form" class="cta-button it-and-contact" data-key="cta-learn-more">Learn More</a>
+      <a href="#form" class="cta-button it-and-contact learn-more" data-key="cta-learn-more">Learn More</a>
     </header>
 
     <section>

--- a/js/langtheme.js
+++ b/js/langtheme.js
@@ -198,6 +198,11 @@ const translations = {
     'cta-strategy-call': "Book Free Strategy Call",
     // Modal button
     'modal-learn-more': "Learn More",
+    'nav-menu': 'Menu',
+    'aria-toggle-language': 'Switch language to Spanish',
+    'aria-toggle-theme': 'Toggle dark mode',
+    'aria-nav-menu': 'Toggle navigation menu',
+    'aria-cta-explore': 'Explore services section',
     'footer-copyright': '© 2025 OPS Online Support.',
   },
   es: {
@@ -244,6 +249,11 @@ const translations = {
     'cta-strategy-call': "Reservar Llamada de Estrategia Gratis",
     // Modal button
     'modal-learn-more': "Aprende Más",
+    'nav-menu': 'Menú',
+    'aria-toggle-language': 'Cambiar idioma a inglés',
+    'aria-toggle-theme': 'Cambiar modo de color',
+    'aria-nav-menu': 'Desplegar menú de navegación',
+    'aria-cta-explore': 'Explorar la sección de servicios',
     'footer-copyright': '© 2025 OPS Online Support.',
   },
 };
@@ -253,6 +263,7 @@ let currentTheme = localStorage.getItem('theme') || 'light';
 
 function updateContent() {
   const elements = document.querySelectorAll('[data-key]');
+  const ariaElements = document.querySelectorAll('[data-aria-label-key]');
   const langButtons = document.querySelectorAll('.lang-toggle');
   const langData = translations[currentLanguage];
 
@@ -278,6 +289,14 @@ function updateContent() {
       } else {
         el.textContent = translation;
       }
+    }
+  });
+
+  ariaElements.forEach(el => {
+    const ariaKey = el.getAttribute('data-aria-label-key');
+    const ariaTranslation = langData[ariaKey];
+    if (ariaTranslation) {
+      el.setAttribute('aria-label', ariaTranslation);
     }
   });
 

--- a/js/main.js
+++ b/js/main.js
@@ -27,7 +27,7 @@ function createModal(serviceKey, lang) {
       </ul>
     </div>
     <div class="modal-actions">
-      <a href="${serviceData.learn}" class="modal-btn" data-key="modal-learn-more"></a>
+      <a href="${serviceData.learn}" class="modal-btn learn-more" data-key="modal-learn-more"></a>
     </div>
   `;
 

--- a/tests/mobile-nav.test.js
+++ b/tests/mobile-nav.test.js
@@ -46,7 +46,7 @@ const pages = ['index.html', 'contact-center.html', 'it-support.html', 'professi
 for (const page of pages) {
   test(`nav links closed by default on ${page}`, () => {
     const html = fs.readFileSync(path.join(root, page), 'utf-8');
-    assert.match(html, /<div class="nav-links">/);
+    assert.match(html, /<div class="nav-links"[^>]*>/);
     assert.ok(!/<div class="nav-links open"/.test(html), 'nav links should not be open by default');
   });
 }


### PR DESCRIPTION
## Summary
- add translation-based aria labels for navigation and CTA buttons
- style `.learn-more` buttons for visible keyboard focus
- adjust tests for updated nav markup

## Testing
- `npm test`
- `npx @axe-core/cli index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68941bdac5b0832ba4a0d285a986487d