### PR TITLE
Improve toggle buttons and modal behavior

### DIFF
--- a/cojoinlistener.js
+++ b/cojoinlistener.js
@@ -33,6 +33,19 @@ document.addEventListener('DOMContentLoaded', () => {
   fabOptions.appendChild(chatbotFab);
 
   let activeModal = null;
+  let overlay = null;
+
+  window.hideActiveFabModal = () => {
+    if (activeModal) {
+      hideModal(activeModal);
+    }
+  };
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && activeModal) {
+      hideModal(activeModal);
+    }
+  });
 
   // Main FAB click handler
   fabMain.addEventListener('click', () => {
@@ -124,10 +137,18 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     }
 
-    // Initialize draggable on window load, then update on resize
-    // This function is expected to be defined in fabs/js/cojoin.js
-    if (window.initDraggableModal) {
-      window.initDraggableModal(modal);
+    if (modal) {
+      removeOverlay();
+      overlay = document.createElement('div');
+      overlay.className = 'modal-overlay';
+      overlay.addEventListener('click', () => hideModal(modal));
+      document.body.appendChild(overlay);
+
+      // Initialize draggable on window load, then update on resize
+      // This function is expected to be defined in fabs/js/cojoin.js
+      if (window.initDraggableModal) {
+        window.initDraggableModal(modal);
+      }
     }
 
     fabContainer.classList.remove('open');
@@ -141,6 +162,21 @@ document.addEventListener('DOMContentLoaded', () => {
     if (modal) {
       modal.style.display = 'none';
       activeModal = null;
+    }
+    removeOverlay();
+  }
+
+  function removeOverlay() {
+    if (overlay) {
+      if (overlay.remove) {
+        overlay.remove();
+      } else if (overlay.parentNode && overlay.parentNode.children) {
+        const idx = overlay.parentNode.children.indexOf(overlay);
+        if (idx > -1) {
+          overlay.parentNode.children.splice(idx, 1);
+        }
+      }
+      overlay = null;
     }
   }
 

--- a/css/style.css
+++ b/css/style.css
@@ -203,8 +203,16 @@ li {
   font-size: 1em;
   cursor: pointer;
   transition: background 0.18s;
-  width: 40px;
   text-align: center;
+}
+
+.toggle-btn {
+  width: auto;
+  min-width: 40px;
+}
+
+.nav-menu-toggle {
+  width: 40px;
 }
 
 .toggle-btn:hover,

--- a/fabs/css/cojoin.css
+++ b/fabs/css/cojoin.css
@@ -83,6 +83,16 @@ body {
 }
 
 /* Modal and Form Styles */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+}
+
 .modal-container {
   position: fixed;
   top: 50%;

--- a/fabs/js/chattia.js
+++ b/fabs/js/chattia.js
@@ -88,6 +88,9 @@ function initChatbot() {
         log.lastChild.textContent = 'Error: Can’t reach AI.';
       }
       send.disabled = false;
+      if (window.hideActiveFabModal) {
+        window.hideActiveFabModal();
+      }
     };
   }
 }

--- a/fabs/js/cojoin.js
+++ b/fabs/js/cojoin.js
@@ -141,6 +141,9 @@ function initCojoinForms() {
     alert('Contact form submitted successfully!');
     await sendToCloudflareWorker(sanitizedData);
     form.reset();
+    if (window.hideActiveFabModal) {
+      window.hideActiveFabModal();
+    }
   }
 
   /**
@@ -184,6 +187,9 @@ function initCojoinForms() {
     await sendToCloudflareWorker(sanitizedData);
     form.reset();
     resetJoinFormState();
+    if (window.hideActiveFabModal) {
+      window.hideActiveFabModal();
+    }
   }
 
   /**

--- a/js/main.js
+++ b/js/main.js
@@ -256,14 +256,6 @@ document.addEventListener('DOMContentLoaded', () => {
     if (serviceData && serviceData.learn) {
       btn.setAttribute('href', serviceData.learn);
     }
-    btn.addEventListener('click', (event) => {
-      // Allow default behavior for modified clicks (new tab, etc.)
-      if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
-        return;
-      }
-      event.preventDefault();
-      createModal(serviceKey, currentLanguage);
-    });
   });
 
   // --- Form Submission Logic ---

--- a/tests/cards-learn-more.test.js
+++ b/tests/cards-learn-more.test.js
@@ -4,19 +4,24 @@ const { JSDOM } = require('jsdom');
 const fs = require('fs');
 const path = require('path');
 
-test('only .learn-more clicks open service modal', () => {
+test('learn-more buttons link to service pages', () => {
   const html = `<!DOCTYPE html><html><body>
     <div id="modal-root"></div>
     <section id="cards-section">
-      <div class="card" data-service-key="ops">
-        <button class="learn-more">Learn More</button>
+      <div class="card" data-service-key="cc">
+        <a class="learn-more">Learn More</a>
       </div>
     </section>
   </body></html>`;
 
-  const dom = new JSDOM(html, { runScripts: 'outside-only', pretendToBeVisual: true });
+  const dom = new JSDOM(html, { runScripts: 'outside-only', url: 'http://example.com/' });
   const { window } = dom;
   window.currentLanguage = 'en';
+  window.translations = {
+    services: {
+      cc: { learn: 'contact-center.html' }
+    }
+  };
 
   const script = fs.readFileSync(path.join(__dirname, '../js/main.js'), 'utf8');
   window.eval(script);
@@ -26,18 +31,9 @@ test('only .learn-more clicks open service modal', () => {
 
   window.document.dispatchEvent(new window.Event('DOMContentLoaded', { bubbles: true }));
 
-  // click on card itself - should not open modal
-  const card = window.document.querySelector('.card');
-  called = false;
-  card.click();
-  assert.equal(called, false, 'card click should not open modal');
-
-  // click on learn-more button - should open modal and stop bubbling
   const btn = window.document.querySelector('.learn-more');
-  let bubbled = false;
-  window.document.addEventListener('click', () => { bubbled = true; });
-  called = false;
+  assert.equal(btn.getAttribute('href'), 'contact-center.html');
   btn.click();
-  assert.equal(called, true, 'learn-more click should open modal');
-  assert.equal(bubbled, false, 'event propagation should stop at container');
+  assert.equal(called, false, 'click should not open modal');
 });
+


### PR DESCRIPTION
## Summary
- ensure language and theme toggles size to their labels
- add overlay with ESC/outside/submit closing for FAB modals
- have card Learn More buttons link directly to service pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68945926a4c4832b8a0f2cbee8234420