### PR TITLE
Add dynamic continued education and experience fields

### DIFF
--- a/contact-center.html
+++ b/contact-center.html
@@ -14,7 +14,7 @@
 <body class="page-contact-center">
   <nav class="ops-nav">
     <div class="ops-logo">OPS</div>
-    <div class="nav-links">
+    <div class="nav-links" id="primary-nav">
       <a href="index.html" class="nav-link" data-key="nav-business-ops">Business Operations</a>
       <a href="contact-center.html" class="nav-link active" data-key="nav-contact-center">Contact Center</a>
       <a href="it-support.html" class="nav-link" data-key="nav-it-support">IT Support</a>

--- a/fabs/join.html
+++ b/fabs/join.html
@@ -86,16 +86,30 @@
         </select>
       </div>
 
-      <div class="form-section">
-        <h2>Continued Education</h2>
+      <div class="form-section" data-section="Continued Education">
+        <div class="section-header">
+          <h2>Continued Education</h2>
+          <div>
+            <button type="button" class="circle-btn add" title="Add field">+</button>
+            <button type="button" class="circle-btn remove" title="Remove last field">−</button>
+          </div>
+        </div>
         <div class="inputs"></div>
-        <button type="button" class="circle-btn add" title="Add field">+</button>
+        <button type="button" class="accept-btn">Accept</button>
+        <button type="button" class="edit-btn" style="display:none;">Edit</button>
       </div>
 
-      <div class="form-section">
-        <h2>Experience</h2>
+      <div class="form-section" data-section="Experience">
+        <div class="section-header">
+          <h2>Experience</h2>
+          <div>
+            <button type="button" class="circle-btn add" title="Add field">+</button>
+            <button type="button" class="circle-btn remove" title="Remove last field">−</button>
+          </div>
+        </div>
         <div class="inputs"></div>
-        <button type="button" class="circle-btn add" title="Add field">+</button>
+        <button type="button" class="accept-btn">Accept</button>
+        <button type="button" class="edit-btn" style="display:none;">Edit</button>
       </div>
 
       <div>

--- a/fabs/js/cojoin.js
+++ b/fabs/js/cojoin.js
@@ -206,11 +206,23 @@ function initCojoinForms() {
 
       if (addBtn) {
         addBtn.addEventListener('click', () => {
-          const input = document.createElement('input');
-          input.type = 'text';
-          input.placeholder = `Enter ${section.querySelector('h2').textContent.toLowerCase()}`;
-          inputsContainer.appendChild(input);
-          input.focus();
+          let field;
+          if (section.dataset.section === 'Experience') {
+            const count = inputsContainer.querySelectorAll('textarea').length + 1;
+            field = document.createElement('textarea');
+            field.rows = 3;
+            field.placeholder = `tell us about your Experience ${count}`;
+          } else if (section.dataset.section === 'Continued Education') {
+            field = document.createElement('textarea');
+            field.rows = 3;
+            field.placeholder = 'Online Courses, Seminars, Webinars with Completion Certification';
+          } else {
+            field = document.createElement('input');
+            field.type = 'text';
+            field.placeholder = `Enter ${section.querySelector('h2').textContent.toLowerCase()}`;
+          }
+          inputsContainer.appendChild(field);
+          field.focus();
         });
       }
 
@@ -226,7 +238,7 @@ function initCojoinForms() {
 
       if (acceptBtn) {
         acceptBtn.addEventListener('click', () => {
-          const inputs = inputsContainer.querySelectorAll('input[type=text]');
+          const inputs = inputsContainer.querySelectorAll('input[type=text], textarea');
           if (inputs.length === 0) {
             alert('Add at least one entry.');
             return;
@@ -267,7 +279,7 @@ function initCojoinForms() {
    * @param {boolean} accepted True to lock the section, false to unlock.
    */
   function toggleSectionState(section, accepted) {
-    const inputs = section.querySelectorAll('input[type=text]');
+    const inputs = section.querySelectorAll('input[type=text], textarea');
     const acceptBtn = section.querySelector('.accept-btn');
     const editBtn = section.querySelector('.edit-btn');
     const addBtn = section.querySelector('.circle-btn.add');

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 <body class="page-business-ops">
   <nav class="ops-nav">
     <div class="ops-logo">OPS</div>
-    <div class="nav-links">
+    <div class="nav-links" id="primary-nav">
       <a href="index.html" class="nav-link active" data-key="nav-business-ops">Business Operations</a>
       <a href="contact-center.html" class="nav-link" data-key="nav-contact-center">Contact Center</a>
       <a href="it-support.html" class="nav-link" data-key="nav-it-support">IT Support</a>

--- a/it-support.html
+++ b/it-support.html
@@ -14,7 +14,7 @@
 <body class="page-it-support">
   <nav class="ops-nav">
     <div class="ops-logo">OPS</div>
-    <div class="nav-links">
+    <div class="nav-links" id="primary-nav">
       <a href="index.html" class="nav-link" data-key="nav-business-ops">Business Operations</a>
       <a href="contact-center.html" class="nav-link" data-key="nav-contact-center">Contact Center</a>
       <a href="it-support.html" class="nav-link active" data-key="nav-it-support">IT Support</a>

--- a/js/main.js
+++ b/js/main.js
@@ -122,9 +122,11 @@ function updateModalContent(modalElement, lang) {
 // Basic sanitization helper
 function sanitizeInput(str) {
   // In a real application, we would use a library like DOMPurify here.
-  // This is a placeholder to simulate the sanitization process.
-  const sanitized = str.replace(/</g, '&lt;').replace(/>/g, '&gt;');
-  return sanitized;
+  // This placeholder removes HTML tags and escapes remaining brackets.
+  return str
+    .replace(/<[^>]*>/g, '')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
 }
 
 // Function to handle form submission

--- a/professional-services.html
+++ b/professional-services.html
@@ -14,7 +14,7 @@
 <body class="page-professional-services">
   <nav class="ops-nav">
     <div class="ops-logo">OPS</div>
-    <div class="nav-links">
+    <div class="nav-links" id="primary-nav">
       <a href="index.html" class="nav-link" data-key="nav-business-ops">Business Operations</a>
       <a href="contact-center.html" class="nav-link" data-key="nav-contact-center">Contact Center</a>
       <a href="it-support.html" class="nav-link" data-key="nav-it-support">IT Support</a>

--- a/tests/join-form.test.js
+++ b/tests/join-form.test.js
@@ -1,0 +1,74 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { JSDOM } = require('jsdom');
+
+function setupDom(html) {
+  const dom = new JSDOM(html);
+  global.window = dom.window;
+  global.document = dom.window.document;
+  global.alert = () => {};
+  global.fetch = () => Promise.resolve({ ok: true });
+  return dom;
+}
+
+test('Experience section adds numbered textareas', () => {
+  const dom = setupDom(`
+    <form id="joinForm">
+      <div class="form-section" data-section="Experience">
+        <div class="section-header">
+          <h2>Experience</h2>
+          <div>
+            <button type="button" class="circle-btn add" title="Add field">+</button>
+            <button type="button" class="circle-btn remove" title="Remove last field">−</button>
+          </div>
+        </div>
+        <div class="inputs"></div>
+        <button type="button" class="accept-btn">Accept</button>
+        <button type="button" class="edit-btn" style="display:none;">Edit</button>
+      </div>
+    </form>
+  `);
+  delete require.cache[require.resolve('../fabs/js/cojoin.js')];
+  require('../fabs/js/cojoin.js');
+  dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+  const addBtn = dom.window.document.querySelector('.form-section[data-section="Experience"] .circle-btn.add');
+  addBtn.click();
+  addBtn.click();
+  const placeholders = [...dom.window.document.querySelectorAll('.form-section[data-section="Experience"] textarea')].map(el => el.placeholder);
+  assert.deepStrictEqual(placeholders, ['tell us about your Experience 1', 'tell us about your Experience 2']);
+  delete global.window;
+  delete global.document;
+  delete global.alert;
+  delete global.fetch;
+});
+
+test('Continued Education section adds textarea with specific placeholder', () => {
+  const dom = setupDom(`
+    <form id="joinForm">
+      <div class="form-section" data-section="Continued Education">
+        <div class="section-header">
+          <h2>Continued Education</h2>
+          <div>
+            <button type="button" class="circle-btn add" title="Add field">+</button>
+            <button type="button" class="circle-btn remove" title="Remove last field">−</button>
+          </div>
+        </div>
+        <div class="inputs"></div>
+        <button type="button" class="accept-btn">Accept</button>
+        <button type="button" class="edit-btn" style="display:none;">Edit</button>
+      </div>
+    </form>
+  `);
+  delete require.cache[require.resolve('../fabs/js/cojoin.js')];
+  require('../fabs/js/cojoin.js');
+  dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+  const addBtn = dom.window.document.querySelector('.form-section[data-section="Continued Education"] .circle-btn.add');
+  addBtn.click();
+  const textarea = dom.window.document.querySelector('.form-section[data-section="Continued Education"] textarea');
+  assert.strictEqual(textarea.placeholder, 'Online Courses, Seminars, Webinars with Completion Certification');
+  delete global.window;
+  delete global.document;
+  delete global.alert;
+  delete global.fetch;
+});
+


### PR DESCRIPTION
## Summary
- add continued education and experience sections with add/remove/accept/edit controls
- handle experience placeholders and education textareas in join form script
- ensure navigation links have primary-nav IDs and improve input sanitization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894da9c048c832bb7e99499ea8c84aa