### PR TITLE
chore: add npm audit and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "chore"
+      include: scope
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm audit --audit-level=high
+      - run: npm test


### PR DESCRIPTION
## Summary
- run `npm audit` in CI to fail on high severity vulnerabilities
- configure Dependabot to watch npm dependencies

## Testing
- `npm test`
- `npm audit --audit-level=high` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6894ee1c8774832ba5f1d430a86cfc34