### PR TITLE
Make OPS logo return to landing page

### DIFF
--- a/contact-center.html
+++ b/contact-center.html
@@ -13,7 +13,7 @@
 </head>
 <body class="page-contact-center">
   <nav class="ops-nav">
-    <div class="ops-logo">OPS</div>
+    <a href="index.html" class="ops-logo" aria-label="OPS Home">OPS</a>
     <div class="nav-links" id="primary-nav">
       <a href="index.html" class="nav-link" data-key="nav-business-ops">Business Operations</a>
       <a href="contact-center.html" class="nav-link active" data-key="nav-contact-center">Contact Center</a>

--- a/css/style.css
+++ b/css/style.css
@@ -154,6 +154,7 @@ li {
   font-weight: bold;
   font-size: 2rem;
   color: var(--clr-text);
+  text-decoration: none;
   letter-spacing: 2px;
   text-shadow: 0 0 8px var(--clr-logo-shadow);
   user-select: none;

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 </head>
 <body class="page-business-ops">
   <nav class="ops-nav">
-    <div class="ops-logo">OPS</div>
+    <a href="index.html" class="ops-logo" aria-label="OPS Home">OPS</a>
     <div class="nav-links" id="primary-nav">
       <a href="index.html" class="nav-link active" data-key="nav-business-ops">Business Operations</a>
       <a href="contact-center.html" class="nav-link" data-key="nav-contact-center">Contact Center</a>

--- a/it-support.html
+++ b/it-support.html
@@ -13,7 +13,7 @@
 </head>
 <body class="page-it-support">
   <nav class="ops-nav">
-    <div class="ops-logo">OPS</div>
+    <a href="index.html" class="ops-logo" aria-label="OPS Home">OPS</a>
     <div class="nav-links" id="primary-nav">
       <a href="index.html" class="nav-link" data-key="nav-business-ops">Business Operations</a>
       <a href="contact-center.html" class="nav-link" data-key="nav-contact-center">Contact Center</a>

--- a/professional-services.html
+++ b/professional-services.html
@@ -13,7 +13,7 @@
 </head>
 <body class="page-professional-services">
   <nav class="ops-nav">
-    <div class="ops-logo">OPS</div>
+    <a href="index.html" class="ops-logo" aria-label="OPS Home">OPS</a>
     <div class="nav-links" id="primary-nav">
       <a href="index.html" class="nav-link" data-key="nav-business-ops">Business Operations</a>
       <a href="contact-center.html" class="nav-link" data-key="nav-contact-center">Contact Center</a>


### PR DESCRIPTION
## Summary
- Make the OPS logo clickable across all site pages and link it back to the landing page
- Ensure logo link retains styling with no underline and includes accessibility label

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894f8cd6884832b8b59465dae007419