### PR TITLE
Add mobile nav backdrop and vertical toggles

### DIFF
--- a/contact-center.html
+++ b/contact-center.html
@@ -27,6 +27,8 @@
     </div>
   </nav>
 
+  <div class="nav-backdrop" hidden></div>
+
   <main id="page-content">
     <header>
       <h1 data-key="header-heading">Connect with Your Customers.</h1>

--- a/css/style.css
+++ b/css/style.css
@@ -717,6 +717,21 @@ body.dark .ops-modal {
     display: block;
     margin-top: 0.5rem;
   }
+
+  .nav-backdrop {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 999;
+  }
+
+  .nav-backdrop.open {
+    display: block;
+  }
 }
 
 @keyframes animated-gradient {

--- a/index.html
+++ b/index.html
@@ -23,9 +23,10 @@
     <div class="toggles">
       <button type="button" class="toggle-btn lang-toggle" aria-pressed="false" aria-label="" data-aria-label-key="aria-toggle-language">EN</button>
       <button type="button" class="toggle-btn theme-toggle" aria-pressed="false" aria-label="" data-aria-label-key="aria-toggle-theme">Dark</button>
+      <button type="button" class="toggle-btn nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav" data-key="nav-menu" aria-label="" data-aria-label-key="aria-nav-menu">Menu</button>
     </div>
-    <button class="nav-menu-toggle" aria-expanded="false" aria-controls="primary-nav" data-key="nav-menu" aria-label="" data-aria-label-key="aria-nav-menu">Menu</button>
   </nav>
+  <div class="nav-backdrop" hidden></div>
   <main id="page-content">
     <header>
       <h1 data-key="header-heading">Empower Your Business. Simplify Your Life.</h1>

--- a/it-support.html
+++ b/it-support.html
@@ -27,6 +27,8 @@
     </div>
   </nav>
 
+  <div class="nav-backdrop" hidden></div>
+
   <main id="page-content">
     <header>
       <h1 data-key="header-heading">Keep Your Systems Secure and Stable</h1>

--- a/js/main.js
+++ b/js/main.js
@@ -204,6 +204,7 @@ function sanitizeInput(str) {
 document.addEventListener('DOMContentLoaded', async () => {
   const navToggle = document.querySelector('.nav-menu-toggle');
   const navLinks = document.querySelector('.nav-links');
+  const navBackdrop = document.querySelector('.nav-backdrop');
   if (navToggle) {
     const updateToggleVisibility = () => {
       navToggle.style.display = window.innerWidth <= 768 ? 'block' : 'none';
@@ -237,6 +238,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     function openMenu() {
       navLinks.classList.add('open');
       navToggle.setAttribute('aria-expanded', 'true');
+      if (navBackdrop) {
+        navBackdrop.classList.add('open');
+        navBackdrop.removeAttribute('hidden');
+        navBackdrop.addEventListener('click', closeMenu);
+      }
       const focusable = navLinks.querySelectorAll('a, button');
       firstFocusable = focusable[0];
       lastFocusable = focusable[focusable.length - 1];
@@ -250,6 +256,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     function closeMenu() {
       navLinks.classList.remove('open');
       navToggle.setAttribute('aria-expanded', 'false');
+      if (navBackdrop) {
+        navBackdrop.classList.remove('open');
+        navBackdrop.setAttribute('hidden', '');
+        navBackdrop.removeEventListener('click', closeMenu);
+      }
       document.removeEventListener('keydown', trapFocus);
       if (lastFocusedElement) {
         lastFocusedElement.focus();

--- a/professional-services.html
+++ b/professional-services.html
@@ -27,6 +27,8 @@
     </div>
   </nav>
 
+  <div class="nav-backdrop" hidden></div>
+
   <main id="page-content">
     <header>
       <h1 data-key="header-heading">Unlock Expertise. Deliver Results.</h1>


### PR DESCRIPTION
## Summary
- Stack language, theme, and menu controls vertically on mobile
- Add mobile nav backdrop that closes the menu when clicked or pressing Escape

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68950353b8ec832b94512f3e0cc26feb