### PR TITLE
feat: add worker test runner

### DIFF
--- a/tests/bundle.js
+++ b/tests/bundle.js
@@ -1,0 +1,25 @@
+// Auto-generated test bundle for Cloudflare Worker
+// Each function dynamically imports a test module.
+export default [
+  async function assetsFunctionsTest() {
+    await import('./assets-functions.test.js');
+  },
+  async function chatbotModalTest() {
+    await import('./chatbot-modal.test.js');
+  },
+  async function cardsLearnMoreTest() {
+    await import('./cards-learn-more.test.js');
+  },
+  async function footerTest() {
+    await import('./footer.test.js');
+  },
+  async function joinFormTest() {
+    await import('./join-form.test.js');
+  },
+  async function mobileNavTest() {
+    await import('./mobile-nav.test.js');
+  },
+  async function securityHeadersTest() {
+    await import('./security-headers.test.js');
+  }
+];

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/worker/testRunner.js
+++ b/worker/testRunner.js
@@ -1,3 +1,18 @@
+/**
+ * Environment bindings required for this Worker.
+ *
+ * Configure these in `wrangler.toml` or via `wrangler secret put` so the
+ * referenced `env.*` variables resolve at runtime:
+ *
+ * - `APPS_SCRIPT_URL` **(secret)**: Webhook that receives test results. Used in
+ *   `notify` when posting `fetch(env.APPS_SCRIPT_URL)`.
+ * - `SECURITY_EMAIL`: Address for MailChannels alerts. Consumed by
+ *   `sendEmail`.
+ * - `PRIVATE_KEY` **(secret)**: PEM key for RSA-PSS SHA-256 signing in
+ *   `signPayload`.
+ * - `AUDIT_LOG`: KV namespace binding storing the `time | date | type | ip`
+ *   audit trail accessed by `logEvent` and `logAlertFailure`.
+ */
 let tests;
 
 async function runAll(env, ip) {

--- a/worker/testRunner.js
+++ b/worker/testRunner.js
@@ -1,0 +1,125 @@
+let tests;
+
+async function runAll(env, ip) {
+  if (!tests) {
+    ({ default: tests } = await import('../tests/bundle.js'));
+  }
+  const results = [];
+  for (const testFn of tests) {
+    const name = testFn.name || 'anonymous';
+    try {
+      await testFn();
+      results.push({ name, status: 'pass' });
+    } catch (err) {
+      const message = err && err.message ? err.message : String(err);
+      let type = 'failure';
+      if (/intrusion/i.test(message)) type = 'intrusion';
+      else if (/injection/i.test(message)) type = 'injection';
+      else if (err instanceof Error) type = 'error';
+      results.push({ name, status: 'fail', error: message, type });
+      await notify(env, type, ip, { name, message });
+    }
+  }
+  return results;
+}
+
+async function notify(env, type, ip, detail) {
+  const now = new Date();
+  const payload = { timestamp: now.toISOString(), type, ip, detail };
+  const signature = await signPayload(payload, env.PRIVATE_KEY);
+  payload.signature = signature;
+  const body = JSON.stringify(payload);
+
+  const operations = [
+    fetch(env.APPS_SCRIPT_URL || 'https://Apps Script here', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body
+    }),
+    sendEmail(env.SECURITY_EMAIL, body),
+    logEvent(env, type, ip, now)
+  ];
+
+  const results = await Promise.allSettled(operations);
+  for (const r of results) {
+    if (r.status === 'rejected') {
+      await logAlertFailure(env, ip, r.reason);
+    }
+  }
+}
+
+async function logEvent(env, type, ip, now) {
+  if (!env.AUDIT_LOG) {
+    console.warn('AUDIT_LOG not configured; event not logged');
+    return;
+  }
+  const row = `${now.toTimeString().split(' ')[0]} | ${now.toISOString().split('T')[0]} | ${type} | ${ip}`;
+  await env.AUDIT_LOG.put(now.toISOString(), row);
+}
+
+async function logAlertFailure(env, ip, error) {
+  console.warn('Alert dispatch failed:', error);
+  if (!env.AUDIT_LOG) {
+    console.warn('AUDIT_LOG not configured; alert_failure not logged');
+    return;
+  }
+  const now = new Date();
+  const row = `${now.toTimeString().split(' ')[0]} | ${now.toISOString().split('T')[0]} | alert_failure | ${ip}`;
+  try {
+    await env.AUDIT_LOG.put(`${now.toISOString()}-alert_failure`, row);
+  } catch (err) {
+    console.warn('Failed to log alert_failure:', err);
+  }
+}
+
+async function sendEmail(address, content) {
+  if (!address) return;
+  return fetch('https://api.mailchannels.net/tx/v1/send', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      personalizations: [{ to: [{ email: address }] }],
+      from: { email: 'noreply@example.com' },
+      subject: 'Security Test Alert',
+      content: [{ type: 'text/plain', value: content }]
+    })
+  });
+}
+
+async function signPayload(data, pemKey) {
+  if (!pemKey) return '';
+  const encoder = new TextEncoder();
+  const der = pemKey.replace(/-----(BEGIN|END) PRIVATE KEY-----/g, '').replace(/\s+/g, '');
+  const binary = atob(der);
+  const buffer = new Uint8Array([...binary].map(c => c.charCodeAt(0))).buffer;
+  const key = await crypto.subtle.importKey(
+    'pkcs8',
+    buffer,
+    { name: 'RSA-PSS', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const signature = await crypto.subtle.sign(
+    { name: 'RSA-PSS', saltLength: 32 },
+    key,
+    encoder.encode(JSON.stringify(data))
+  );
+  return btoa(String.fromCharCode(...new Uint8Array(signature)));
+}
+
+export { notify, logAlertFailure };
+
+export default {
+  async scheduled(event, env, ctx) {
+    const ip = event.request?.headers.get('cf-connecting-ip') || 'n/a';
+    await runAll(env, ip);
+  },
+  async fetch(request, env, ctx) {
+    if (request.method === 'POST') {
+      const ip = request.headers.get('cf-connecting-ip') || 'n/a';
+      ctx.waitUntil(runAll(env, ip));
+      return new Response('Tests triggered', { status: 202 });
+    }
+    return new Response('OK');
+  }
+};

--- a/worker/testRunner.test.cjs
+++ b/worker/testRunner.test.cjs
@@ -1,0 +1,64 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+let notify, logAlertFailure;
+
+test.before(async () => {
+  ({ notify, logAlertFailure } = await import('./testRunner.js'));
+});
+
+test('notify routes channel failures to logAlertFailure', async (t) => {
+  const entries = [];
+  const putMock = t.mock.fn((key, value) => {
+    if (key.includes('alert_failure')) {
+      entries.push(value);
+      return Promise.resolve();
+    }
+    return Promise.reject(new Error('kv fail'));
+  });
+  const env = {
+    APPS_SCRIPT_URL: 'https://example.com',
+    SECURITY_EMAIL: 'team@example.com',
+    AUDIT_LOG: { put: putMock }
+  };
+  t.mock.method(global, 'fetch', () => Promise.reject(new Error('network')));
+  const warnMock = t.mock.method(console, 'warn');
+
+  await notify(env, 'failure', '203.0.113.10', { name: 't', message: 'oops' });
+
+  assert.strictEqual(entries.length, 3, 'three alert_failure entries logged');
+  assert.strictEqual(warnMock.mock.callCount(), 3, 'console.warn called for each failure');
+});
+
+test('logAlertFailure warns if KV put fails', async (t) => {
+  const putMock = t.mock.fn(() => Promise.reject(new Error('kv offline')));
+  const env = { AUDIT_LOG: { put: putMock } };
+  const warnMock = t.mock.method(console, 'warn');
+
+  await logAlertFailure(env, '198.51.100.5', new Error('fail'));
+
+  assert.strictEqual(putMock.mock.callCount(), 1);
+  assert.strictEqual(warnMock.mock.callCount(), 2);
+  assert.match(warnMock.mock.calls[1].arguments[0], /Failed to log alert_failure/);
+});
+
+test('notify warns when AUDIT_LOG missing', async (t) => {
+  const env = { APPS_SCRIPT_URL: 'https://example.com' };
+  const warnMock = t.mock.method(console, 'warn');
+  t.mock.method(global, 'fetch', () => Promise.resolve(new Response('ok')));
+
+  await notify(env, 'failure', '192.0.2.1', { name: 't', message: 'fail' });
+
+  assert.strictEqual(warnMock.mock.callCount(), 1);
+  assert.match(warnMock.mock.calls[0].arguments[0], /AUDIT_LOG not configured; event not logged/);
+});
+
+test('logAlertFailure warns when AUDIT_LOG missing', async (t) => {
+  const env = {};
+  const warnMock = t.mock.method(console, 'warn');
+
+  await logAlertFailure(env, '203.0.113.2', new Error('oops'));
+
+  assert.strictEqual(warnMock.mock.callCount(), 2);
+  assert.match(warnMock.mock.calls[1].arguments[0], /AUDIT_LOG not configured; alert_failure not logged/);
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,15 @@
+name = "test-runner"
+main = "worker/testRunner.js"
+compatibility_date = "2024-06-20"
+
+[triggers]
+crons = ["1 0 * * *", "13 15 * * *"]
+
+[kv_namespaces]
+[[kv_namespaces]]
+binding = "AUDIT_LOG"
+id = "your_kv_namespace_id"
+
+[vars]
+APPS_SCRIPT_URL = "https://Apps Script here"
+# SECURITY_EMAIL and PRIVATE_KEY should be added via `wrangler secret put`


### PR DESCRIPTION
## Summary
- bundle browser tests for Cloudflare Worker
- add Worker that runs tests on a schedule, signs results and sends alerts
- configure Worker schedule and KV binding
- log webhook/email/log failures and record `alert_failure` entries
- add unit tests for alert failure handling
- warn when `AUDIT_LOG` binding missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894ff2af994832ba719ad1d765920ef