### PR TITLE
fix: adjust CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,17 +2,20 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
+    branches: [main]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: '20'
           cache: 'npm'
       - run: npm ci
       - run: npm audit --audit-level=high
+        continue-on-error: true
       - run: npm test


### PR DESCRIPTION
## Summary
- run CI only on `main` branch
- switch to `actions/setup-node@v3`
- allow `npm audit` warnings without blocking the build

## Testing
- `npm test` *(fails: SyntaxError: await is only valid in async functions)*

------
https://chatgpt.com/codex/tasks/task_e_689574261d6c832b81965c5a9edaa0f5