### PR TITLE
Adjust chatbot styling and controls

### DIFF
--- a/fabs/chatbot.html
+++ b/fabs/chatbot.html
@@ -20,7 +20,9 @@
       <button id="chatbot-send" type="submit" disabled aria-label="Send">
         <i class="fas fa-arrow-right"></i>
       </button>
-      <button id="chatbot-close" type="button" class="modal-close" aria-label="Close">Close</button>
+      <button id="chatbot-close" type="button" class="modal-close" aria-label="Close">
+        <i class="fas fa-times"></i>
+      </button>
     </form>
    </div>
 </div>

--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -12,7 +12,7 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
 
 /* ---------- CHATBOT ---------- */
 #chatbot-container{
-  width: 300px;
+  width: 310px;
   height: 540px;
   background:#251541;
   border:2px solid var(--clr-accent);
@@ -63,23 +63,26 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
 .bot {margin-right:auto;background:#321b53;color:#fff;padding:.5rem .7rem;border-radius:14px 14px 14px 0}
 #chatbot-form-container{background:#220f3a;border-top:1px solid var(--clr-accent);padding:.55rem .7rem}
 #chatbot-input-row{display:flex;gap:.6rem}
-#chatbot-input{flex:1;background:transparent;border:none;color:#fff;font-size:.95rem;padding:.55rem .6rem}
+#chatbot-input{flex:1;background:transparent;border:none;color:#000;font-size:.95rem;padding:.55rem .6rem}
+#chatbot-input::placeholder{color:#000}
 #chatbot-send, #chatbot-close{
   display:flex;
   align-items:center;
-  gap:6px;
+  justify-content:center;
+  width:2rem;
+  height:2rem;
   background:var(--clr-accent);
   border:none;
   color:#fff;
   font-weight:600;
-  padding:.5rem .9rem;
   border-radius:8px;
   cursor:pointer;
   transition:.3s;
+  padding:0;
 }
-#chatbot-send i{font-size:0.5em;transition:transform .3s}
+#chatbot-send i,#chatbot-close i{font-size:0.25em;transition:transform .3s}
 #chatbot-send:hover i{transform:rotate(-45deg)}
 #chatbot-send:disabled{background:#555;cursor:not-allowed}
-#chatbot-close{margin-left:.3rem}
+#chatbot-close{margin-left:0}
 .human-check{color:#ddd;font-size:.85rem;display:flex;align-items:center;margin-top:.3rem}
 .human-check input{margin-right:.4rem}


### PR DESCRIPTION
## Summary
- widen Chattia modal by 10px
- style message input text and placeholder in black
- shrink send icon and align close button as matching icon controls

## Testing
- `npm test` *(fails: SyntaxError: await is only valid in async functions and the top level bodies of modules)*

------
https://chatgpt.com/codex/tasks/task_e_689585fc66f8832ba1820c57e197d122