### PR TITLE
Update mobile CI page paths for FAB modal tests

### DIFF
--- a/ops_mobile_ci.js
+++ b/ops_mobile_ci.js
@@ -1,0 +1,27 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+// Pages used in mobile CI checks. Ensure each page includes
+// the FAB loader script so modal tests can run properly.
+const pages = [
+  '/index.html',
+  '/contact-center.html',
+  '/it-support.html',
+  '/professional-services.html',
+  '/fabs/join.html'
+];
+
+const root = __dirname;
+
+for (const page of pages) {
+  const filePath = path.join(root, page);
+  const html = fs.readFileSync(filePath, 'utf8');
+  // Modal fragments under /fabs/ don't include FAB buttons directly.
+  if (!page.startsWith('/fabs/')) {
+    if (!html.includes('cojoinlistener.js')) {
+      throw new Error(`FAB buttons missing on ${page}`);
+    }
+  }
+}
+
+module.exports = pages;


### PR DESCRIPTION
## Summary
- add ops_mobile_ci.js listing current site pages for mobile modal testing
- verify each HTML page includes cojoinlistener.js so FAB buttons render

## Testing
- `node ops_mobile_ci.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68964add22a8832b84acc63832107af0