### PR TITLE
Use rem units for spacing variables

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -28,13 +28,13 @@
   --bg-gradient-dark: #121212;
 
   /* Spacing */
-  --space-xs: 8px;
-  --space-sm: 10px;
-  --space-md: 20px;
-  --space-lg: 30px;
-  --space-xl: 40px;
-  --space-2xl: 50px;
-  --space-3xl: 60px;
+  --space-xs: 0.5rem;
+  --space-sm: 0.625rem;
+  --space-md: 1.25rem;
+  --space-lg: 1.875rem;
+  --space-xl: 2.5rem;
+  --space-2xl: 3.125rem;
+  --space-3xl: 3.75rem;
 }
 
 /* Dark Theme Variables */
@@ -267,13 +267,13 @@ li {
 
 /* CTA Buttons */
 .cta-button {
-  margin-top: 50px;
+  margin-top: var(--space-2xl);
   display: inline-block;
   color: white;
   text-decoration: none;
   font-weight: 700;
   border-radius: 6px;
-  padding: 14px 30px;
+  padding: 0.875rem var(--space-lg);
   font-size: 1.1rem;
   user-select: none;
   cursor: pointer;
@@ -291,7 +291,7 @@ li {
 
 .cta-button.it-and-contact {
   background: linear-gradient(45deg, var(--clr-cta-other), #7e57c2);
-  padding: 16px 38px;
+  padding: 1rem 2.375rem;
   font-size: 1.15rem;
   border-radius: 10px;
   box-shadow: 0 8px 25px rgba(171, 71, 188, 0.6);
@@ -307,7 +307,7 @@ li {
   max-width: 480px;
   margin: 0 auto var(--space-3xl);
   background: var(--clr-form-bg);
-  padding: 30px 30px 40px;
+  padding: var(--space-lg) var(--space-lg) var(--space-xl);
   border-radius: 14px;
   box-shadow: 0 8px 40px rgba(0, 0, 0, 0.2);
   transition: background 0.3s, color 0.3s;
@@ -356,7 +356,7 @@ li {
 }
 
 .business-ops-form {
-  margin-top: 50px;
+  margin-top: var(--space-2xl);
 }
 
 /* Business Ops Specific Components */
@@ -365,7 +365,7 @@ li {
   margin: 0 auto;
   margin-top: 2.8rem;
   display: grid;
-  gap: 50px; /* ≈200 px total spacing (3 gaps × 50px + 50px outer margins) */
+  gap: var(--space-2xl); /* ≈200px total spacing (3 gaps × var(--space-2xl) + var(--space-2xl) outer margins) */
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
 }
 
@@ -463,7 +463,7 @@ body.dark .card .icon > i {
 .client-story-section figcaption {
   font-weight: 700;
   display: block;
-  margin-top: 10px;
+  margin-top: var(--space-sm);
   color: var(--clr-text);
 }
 
@@ -532,8 +532,8 @@ body.dark .ops-modal {
 .modal-features li {
   position: relative;
   font-size: 1rem;
-  margin-bottom: 8px;
-  padding-left: 20px;
+  margin-bottom: var(--space-xs);
+  padding-left: var(--space-md);
 }
 .modal-features li::before {
   content: "✓";
@@ -635,7 +635,7 @@ body.dark .ops-modal {
     font-size: 2.2rem;
   }
   .cta-button.it-and-contact {
-    padding: 14px 30px;
+    padding: 0.875rem var(--space-lg);
     font-size: 1.1rem;
   }
   .contact-form-section {
@@ -684,7 +684,7 @@ body.dark .ops-modal {
   }
 
   .cta-button.it-and-contact {
-    padding: 14px 30px;
+    padding: 0.875rem var(--space-lg);
     font-size: 1.1rem;
   }
 


### PR DESCRIPTION
## Summary
- replace pixel-based `--space-*` CSS variables with rem equivalents
- adjust component padding and margins to consume new spacing variables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68964ada56ec832b8c86fb074ca3f062