### PR TITLE
refactor fab stack and class names

### DIFF
--- a/cojoinlistener.js
+++ b/cojoinlistener.js
@@ -10,27 +10,23 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const body = document.body;
 
-  // Create the FAB container and buttons
-  const fabContainer = document.createElement('div');
-  fabContainer.className = 'fab-container';
-  body.appendChild(fabContainer);
+  // Create the FAB stack and buttons
+  const fabStack = document.createElement('div');
+  fabStack.className = 'fab-stack';
+  body.appendChild(fabStack);
 
-  const fabMain = document.createElement('button');
-  fabMain.className = 'fab-main';
-  fabMain.innerHTML = '<i class="fas fa-plus"></i>';
-  fabContainer.appendChild(fabMain);
+  const fabMenu = document.createElement('button');
+  fabMenu.className = 'fab fab--menu';
+  fabMenu.innerHTML = '<i class="fas fa-plus"></i>';
+  fabStack.appendChild(fabMenu);
 
-  const fabOptions = document.createElement('div');
-  fabOptions.className = 'fab-options';
-  fabContainer.appendChild(fabOptions);
+  const contactFab = createFab('contact', '<i class="fa fa-envelope"></i>', 'Contact Us');
+  const joinFab = createFab('join', '<i class="fa fa-user-plus"></i>', 'Join Us');
+  const chatbotFab = createFab('chatbot', '<i class="fa fa-comments"></i>', 'Chatbot');
 
-  const contactFab = createFabOption('contact', '<i class="fa fa-envelope"></i>', 'Contact Us');
-  const joinFab = createFabOption('join', '<i class="fa fa-user-plus"></i>', 'Join Us');
-  const chatbotFab = createFabOption('chatbot', '<i class="fa fa-comments"></i>', 'Chatbot');
-
-  fabOptions.appendChild(contactFab);
-  fabOptions.appendChild(joinFab);
-  fabOptions.appendChild(chatbotFab);
+  fabStack.appendChild(contactFab);
+  fabStack.appendChild(joinFab);
+  fabStack.appendChild(chatbotFab);
 
   let activeModal = null;
   let overlay = null;
@@ -51,15 +47,15 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   // Main FAB click handler
-  fabMain.addEventListener('click', () => {
-    fabContainer.classList.toggle('open');
+  fabMenu.addEventListener('click', () => {
+    fabStack.classList.toggle('open');
     // Removed shine animation to prevent spinning effect on click
-    // fabMain.classList.add('shine');
+    // fabMenu.classList.add('shine');
     // setTimeout(() => {
-    //   fabMain.classList.remove('shine');
+    //   fabMenu.classList.remove('shine');
     // }, 600);
     // If FABs close, also close the active modal
-    if (!fabContainer.classList.contains('open') && activeModal) {
+    if (!fabStack.classList.contains('open') && activeModal) {
       hideModal(activeModal);
     }
   });
@@ -78,15 +74,15 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   /**
-   * Creates a single FAB option button.
+   * Creates a single FAB button.
    * @param {string} id The unique ID for the button.
    * @param {string} icon The HTML for the Font Awesome icon.
    * @param {string} title The title/aria-label for accessibility.
    * @returns {HTMLButtonElement} The created button element.
    */
-  function createFabOption(id, icon, title) {
+  function createFab(id, icon, title) {
     const button = document.createElement('button');
-    button.className = 'fab-option';
+    button.className = `fab fab--${id}`;
     button.id = `fab-${id}`;
     button.innerHTML = icon;
     button.title = title;
@@ -203,7 +199,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     }
 
-    fabContainer.classList.remove('open');
+    fabStack.classList.remove('open');
   }
 
   /**

--- a/fabs/css/cojoin.css
+++ b/fabs/css/cojoin.css
@@ -20,8 +20,8 @@ body {
   color: var(--clr-tx);
 }
 
-/* Floating Action Button (FAB) Container */
-.fab-container {
+/* Floating Action Button (FAB) Stack */
+.fab-stack {
   position: fixed;
   bottom: 40px;
   right: 10px;
@@ -32,50 +32,8 @@ body {
   gap: 15px;
 }
 
-.fab-main {
-  width: 60px;
-  height: 60px;
-  background: linear-gradient(135deg, var(--clr-primary), var(--clr-accent));
-  color: white;
-  border-radius: 50%;
-  border: none;
-  font-size: 24px;
-  cursor: pointer;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
-  transition: transform 0.3s ease;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  position: relative;
-  overflow: visible;
-  isolation: isolate;
-}
-
-.fab-main:hover {
-  transform: scale(1.1);
-}
-
-.fab-main::before {
-  content: '';
-  position: absolute;
-  inset: -4px;
-  border-radius: 50%;
-  background: linear-gradient(90deg, transparent, #ff9966, #ff9966, #ff9966, #ff9966, transparent);
-  opacity: 0;
-  pointer-events: none;
-  z-index: -1;
-}
-
-/* Removed shine animation and associated keyframes */
-
-.fab-options {
-  display: flex;
-  flex-direction: column-reverse;
-  align-items: center;
-  gap: 10px;
-}
-
-.fab-option {
+/* Base FAB styles */
+.fab {
   width: 50px;
   height: 50px;
   background: var(--clr-accent);
@@ -93,7 +51,36 @@ body {
   transition: opacity 0.3s, transform 0.3s;
 }
 
-.fab-container.open .fab-option {
+/* Menu FAB */
+.fab--menu {
+  width: 60px;
+  height: 60px;
+  background: linear-gradient(135deg, var(--clr-primary), var(--clr-accent));
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  font-size: 24px;
+  opacity: 1;
+  transform: scale(1);
+  position: relative;
+  overflow: visible;
+  isolation: isolate;
+}
+
+.fab--menu:hover {
+  transform: scale(1.1);
+}
+
+.fab--menu::before {
+  content: '';
+  position: absolute;
+  inset: -4px;
+  border-radius: 50%;
+  background: linear-gradient(90deg, transparent, #ff9966, #ff9966, #ff9966, #ff9966, transparent);
+  opacity: 0;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.fab-stack.open .fab {
   opacity: 1;
   transform: scale(1);
 }

--- a/tests/ui/nav_and_fab_layout.test.js
+++ b/tests/ui/nav_and_fab_layout.test.js
@@ -8,14 +8,14 @@ const root = path.resolve(__dirname, '..', '..');
 
 // Ensure FAB container positioning
 
-test('fab container fixed to viewport corner', () => {
+test('fab stack fixed to viewport corner', () => {
   const css = fs.readFileSync(path.join(root, 'fabs', 'css', 'cojoin.css'), 'utf-8');
-  const match = css.match(/\.fab-container\s*{[\s\S]*?}/);
-  assert.ok(match, 'fab-container styles not found');
+  const match = css.match(/\.fab-stack\s*{[\s\S]*?}/);
+  assert.ok(match, 'fab-stack styles not found');
   const block = match[0];
-  assert.ok(/position:\s*fixed/.test(block), 'fab container should be fixed');
-  assert.ok(/bottom:\s*40px/.test(block), 'fab container should be 40px from bottom');
-  assert.ok(/right:\s*10px/.test(block), 'fab container should be 10px from right');
+  assert.ok(/position:\s*fixed/.test(block), 'fab stack should be fixed');
+  assert.ok(/bottom:\s*40px/.test(block), 'fab stack should be 40px from bottom');
+  assert.ok(/right:\s*10px/.test(block), 'fab stack should be 10px from right');
 });
 
 // Ensure clicking outside or on backdrop closes mobile menu


### PR DESCRIPTION
## Summary
- adopt standardized FAB markup with new fab-stack container and per-action classes
- update FAB styles to match new class names and menu button
- adjust UI test to target new FAB stack selector

## Testing
- `npm test`
- `node cojoinlistener.js manual checks`

------
https://chatgpt.com/codex/tasks/task_e_68964adefafc832bae687c3fa3e38189