### PR TITLE
chore: add http-server dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "NODE_PATH=./node_modules node --test"
   },
   "devDependencies": {
+    "http-server": "^14.1.1",
     "jsdom": "24.0.0"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- add http-server dev dependency for local server usage

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/http-server)*
- `npm test` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68964ae03fe8832b9e5f2c76b2de27a8