### PR TITLE
Enhance modal layout with responsive viewport sizing

### DIFF
--- a/cojoinlistener.js
+++ b/cojoinlistener.js
@@ -182,9 +182,12 @@ document.addEventListener('DOMContentLoaded', () => {
     if (modal) {
       removeOverlay();
       overlay = document.createElement('div');
-      overlay.className = 'modal-overlay';
+      overlay.className = 'backdrop';
+      overlay.dataset.open = 'true';
       overlay.addEventListener('click', () => hideModal(modal));
       document.body.appendChild(overlay);
+      document.documentElement.dataset.lock = 'true';
+      document.body.dataset.lock = 'true';
 
       // Initialize draggable on window load, then update on resize
       // This function is expected to be defined in fabs/js/cojoin.js
@@ -234,6 +237,12 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       }
       overlay = null;
+    }
+    if (document.documentElement && document.documentElement.dataset) {
+      delete document.documentElement.dataset.lock;
+    }
+    if (document.body && document.body.dataset) {
+      delete document.body.dataset.lock;
     }
   }
 

--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -12,8 +12,10 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
 
 /* ---------- CHATBOT ---------- */
 #chatbot-container{
-  width: 310px;
-  height: 540px;
+  width: 90vw;
+  max-width: 400px;
+  height: 90dvh;
+  max-height: 600px;
   background:#251541;
   border:2px solid var(--clr-accent);
   border-radius:18px;
@@ -39,17 +41,22 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
   font-size:1.1rem;
   padding:.75rem 1rem;
   cursor: move;
+  position: sticky;
+  top: 0;
+  z-index: 1;
 }
 #chatbot-header #title{color:#000;}
 @media (max-width: 767px) {
   #chatbot-container {
-    width: 100%;
-    height: 100%;
+    width: 100vw;
+    height: 100dvh;
     border-radius: 0;
     top: 0;
     left: 0;
     transform: none;
     overflow-y: auto;
+    max-width: none;
+    max-height: none;
   }
   #chatbot-header {
     cursor: default;
@@ -61,7 +68,7 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
 .chat-msg{margin:.5rem 0;max-width:90%}
 .user{margin-left:auto;background:var(--clr-primary);color:#000;padding:.5rem .7rem;border-radius:14px 14px 0 14px}
 .bot {margin-right:auto;background:#321b53;color:#fff;padding:.5rem .7rem;border-radius:14px 14px 14px 0}
-#chatbot-form-container{background:#220f3a;border-top:1px solid var(--clr-accent);padding:.55rem .7rem}
+#chatbot-form-container{background:#220f3a;border-top:1px solid var(--clr-accent);padding:.55rem .7rem;position:sticky;bottom:0;z-index:1}
 #chatbot-input-row{display:flex;gap:.6rem}
 #chatbot-input{flex:1;background:transparent;border:none;color:#000;font-size:.95rem;padding:.55rem .6rem}
 #chatbot-input::placeholder{color:#000}

--- a/fabs/css/cojoin.css
+++ b/fabs/css/cojoin.css
@@ -98,15 +98,23 @@ body {
   transform: scale(1);
 }
 
+/* Lock body scrolling when a modal is open */
+html[data-lock="true"],
+body[data-lock="true"] {
+  overflow: hidden;
+}
+
 /* Modal and Form Styles */
-.modal-overlay {
+.backdrop {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  inset: 0;
   background: rgba(0, 0, 0, 0.5);
   z-index: 1000;
+  display: none;
+}
+
+.backdrop[data-open="true"] {
+  display: block;
 }
 
 .modal-container {
@@ -114,9 +122,10 @@ body {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 90%;
+  width: 90vw;
   max-width: 600px;
-  max-height: 90vh;
+  height: 90dvh;
+  max-height: 90dvh;
   background: var(--clr-bg);
   border-radius: 12px;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
@@ -130,8 +139,8 @@ body {
   .modal-container {
     top: 0;
     left: 0;
-    width: 100%;
-    height: 100%;
+    width: 100vw;
+    height: 100dvh;
     max-width: none;
     max-height: none;
     transform: none;
@@ -150,6 +159,9 @@ body {
   border-top-left-radius: 12px;
   border-top-right-radius: 12px;
   cursor: move; /* Draggable on large screens */
+  position: sticky;
+  top: 0;
+  z-index: 1;
 }
 
 @media (max-width: 767px) {
@@ -289,6 +301,10 @@ input, select, textarea {
 .modal-footer {
   margin-top: 2rem;
   text-align: center;
+  position: sticky;
+  bottom: 0;
+  background: var(--clr-bg);
+  padding-bottom: 1rem;
 }
 
 button.submit-btn {


### PR DESCRIPTION
## Summary
- size contact, join, and chatbot modals with vw/dvh for better responsiveness
- add backdrop overlay and HTML/body lock while modals are open
- make modal headers and footers sticky so content scrolls independently

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68964ae8d5e8832bb71bffd91e1a27c6