### PR TITLE
feat: add safe-area FAB stack

### DIFF
--- a/fabs/css/cojoin.css
+++ b/fabs/css/cojoin.css
@@ -20,64 +20,23 @@ body {
   color: var(--clr-tx);
 }
 
-/* Floating Action Button (FAB) Container */
-.fab-container {
+/* Floating Action Button (FAB) Stack */
+.fab-stack {
   position: fixed;
-  bottom: 40px;
-  right: 10px;
+  bottom: calc(env(safe-area-inset-bottom) + 16px);
+  right: calc(env(safe-area-inset-right) + 16px);
   z-index: 1000;
   display: flex;
-  flex-direction: column-reverse;
+  flex-direction: column;
   align-items: flex-end;
-  gap: 15px;
-}
-
-.fab-main {
-  width: 60px;
-  height: 60px;
-  background: linear-gradient(135deg, var(--clr-primary), var(--clr-accent));
-  color: white;
-  border-radius: 50%;
-  border: none;
-  font-size: 24px;
-  cursor: pointer;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
-  transition: transform 0.3s ease;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  position: relative;
-  overflow: visible;
-  isolation: isolate;
-}
-
-.fab-main:hover {
-  transform: scale(1.1);
-}
-
-.fab-main::before {
-  content: '';
-  position: absolute;
-  inset: -4px;
-  border-radius: 50%;
-  background: linear-gradient(90deg, transparent, #ff9966, #ff9966, #ff9966, #ff9966, transparent);
-  opacity: 0;
-  pointer-events: none;
-  z-index: -1;
-}
-
-/* Removed shine animation and associated keyframes */
-
-.fab-options {
-  display: flex;
-  flex-direction: column-reverse;
-  align-items: center;
   gap: 10px;
 }
 
-.fab-option {
-  width: 50px;
-  height: 50px;
+.fab-stack__button {
+  width: 56px;
+  height: 56px;
+  min-width: 48px;
+  min-height: 48px;
   background: var(--clr-accent);
   color: white;
   border-radius: 50%;
@@ -88,15 +47,12 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  opacity: 0;
-  transform: scale(0);
-  transition: opacity 0.3s, transform 0.3s;
 }
 
-.fab-container.open .fab-option {
-  opacity: 1;
-  transform: scale(1);
-}
+.fab-stack__contact { background: var(--clr-primary); }
+.fab-stack__join { background: var(--clr-accent); }
+.fab-stack__chatbot { background: var(--clr-accent-dark); }
+.fab-stack__menu { background: var(--clr-primary); }
 
 /* Modal and Form Styles */
 .modal-overlay {

--- a/tests/ui/nav_and_fab_layout.test.js
+++ b/tests/ui/nav_and_fab_layout.test.js
@@ -8,14 +8,33 @@ const root = path.resolve(__dirname, '..', '..');
 
 // Ensure FAB container positioning
 
-test('fab container fixed to viewport corner', () => {
+test('fab stack uses safe-area margins and button sizes', () => {
   const css = fs.readFileSync(path.join(root, 'fabs', 'css', 'cojoin.css'), 'utf-8');
-  const match = css.match(/\.fab-container\s*{[\s\S]*?}/);
-  assert.ok(match, 'fab-container styles not found');
-  const block = match[0];
-  assert.ok(/position:\s*fixed/.test(block), 'fab container should be fixed');
-  assert.ok(/bottom:\s*40px/.test(block), 'fab container should be 40px from bottom');
-  assert.ok(/right:\s*10px/.test(block), 'fab container should be 10px from right');
+  const stackMatch = css.match(/\.fab-stack\s*{[\s\S]*?}/);
+  assert.ok(stackMatch, 'fab-stack styles not found');
+  const stackBlock = stackMatch[0];
+  assert.ok(/position:\s*fixed/.test(stackBlock), 'fab stack should be fixed');
+  assert.ok(/bottom:\s*calc\(env\(safe-area-inset-bottom\) \+ 16px\)/.test(stackBlock), 'bottom margin should use safe-area inset');
+  assert.ok(/right:\s*calc\(env\(safe-area-inset-right\) \+ 16px\)/.test(stackBlock), 'right margin should use safe-area inset');
+
+  const btnMatch = css.match(/\.fab-stack__button\s*{[\s\S]*?}/);
+  assert.ok(btnMatch, 'fab-stack__button styles not found');
+  const btnBlock = btnMatch[0];
+  const width = parseInt(btnBlock.match(/width:\s*(\d+)px/)[1], 10);
+  const height = parseInt(btnBlock.match(/height:\s*(\d+)px/)[1], 10);
+  assert.ok(width >= 48, 'fab width should be at least 48px');
+  assert.ok(height >= 48, 'fab height should be at least 48px');
+});
+
+test('fab stack renders buttons in order', () => {
+  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { runScripts: 'dangerously', url: 'http://localhost' });
+  const { window } = dom;
+  window.fetch = async () => ({ text: async () => '<div></div>' });
+  const code = fs.readFileSync(path.join(root, 'cojoinlistener.js'), 'utf-8');
+  window.eval(code);
+  window.document.dispatchEvent(new window.Event('DOMContentLoaded'));
+  const ids = Array.from(window.document.querySelectorAll('.fab-stack__button')).map(b => b.id);
+  assert.deepStrictEqual(ids, ['fab-contact', 'fab-join', 'fab-chatbot', 'fab-menu']);
 });
 
 // Ensure clicking outside or on backdrop closes mobile menu


### PR DESCRIPTION
## Summary
- replace legacy FAB container with `.fab-stack`
- add Contact, Join, Chatbot, and Menu FABs sized 56px with safe-area margins
- update tests for new FAB stack ordering and layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68964aea6660832ba3d01f06004646ad