### PR TITLE
Move mobile nav to FAB

### DIFF
--- a/cojoinlistener.js
+++ b/cojoinlistener.js
@@ -7,20 +7,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const body = document.body;
 
-  // Build FAB stack container
-  const fabStack = document.createElement('div');
-  fabStack.className = 'fab-stack';
-  body.appendChild(fabStack);
-
-  // Create individual FABs
-  const contactFab = createFab('contact', '<i class="fa fa-envelope"></i>', 'Contact Us', 'fab-stack__contact');
-  const joinFab = createFab('join', '<i class="fa fa-user-plus"></i>', 'Join Us', 'fab-stack__join');
-  const chatbotFab = createFab('chatbot', '<i class="fa fa-comments"></i>', 'Chatbot', 'fab-stack__chatbot');
-  const menuFab = createFab('menu', '<i class="fa fa-bars"></i>', 'Menu', 'fab-stack__menu');
-  fabStack.appendChild(contactFab);
-  fabStack.appendChild(joinFab);
-  fabStack.appendChild(chatbotFab);
-  fabStack.appendChild(menuFab);
+  let fabStack = null;
   let activeModal = null;
   let overlay = null;
   let lastFocused = null; // Remember focus to restore when modal closes
@@ -37,16 +24,51 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  // Attach handlers
-  contactFab.addEventListener('click', () => showModal('contact'));
-  joinFab.addEventListener('click', () => showModal('join'));
-  chatbotFab.addEventListener('click', () => showModal('chatbot'));
-  menuFab.addEventListener('click', () => {
-    const navToggle = document.querySelector('.nav-menu-toggle');
-    if (navToggle && navToggle.click) {
-      navToggle.click();
+  function buildFabStack() {
+    if (fabStack) return;
+
+    fabStack = document.createElement('div');
+    fabStack.className = 'fab-stack';
+    body.appendChild(fabStack);
+
+    const contactFab = createFab('contact', '<i class="fa fa-envelope"></i>', 'Contact Us', 'fab-stack__contact');
+    const joinFab = createFab('join', '<i class="fa fa-user-plus"></i>', 'Join Us', 'fab-stack__join');
+    const chatbotFab = createFab('chatbot', '<i class="fa fa-comments"></i>', 'Chatbot', 'fab-stack__chatbot');
+    const menuFab = createFab('menu', '<i class="fa fa-bars"></i>', 'Menu', 'fab-stack__menu');
+
+    fabStack.appendChild(contactFab);
+    fabStack.appendChild(joinFab);
+    fabStack.appendChild(chatbotFab);
+    fabStack.appendChild(menuFab);
+
+    contactFab.addEventListener('click', () => showModal('contact'));
+    joinFab.addEventListener('click', () => showModal('join'));
+    chatbotFab.addEventListener('click', () => showModal('chatbot'));
+    menuFab.addEventListener('click', () => {
+      const navToggle = document.querySelector('.nav-menu-toggle');
+      if (navToggle && navToggle.click) {
+        navToggle.click();
+      }
+    });
+  }
+
+  function removeFabStack() {
+    if (fabStack) {
+      fabStack.remove();
+      fabStack = null;
     }
-  });
+  }
+
+  function checkFabVisibility() {
+    if (window.innerWidth <= 768) {
+      buildFabStack();
+    } else {
+      removeFabStack();
+    }
+  }
+
+  checkFabVisibility();
+  window.addEventListener('resize', checkFabVisibility);
 
   /**
    * Create a single FAB button.

--- a/css/style.css
+++ b/css/style.css
@@ -260,6 +260,7 @@ li {
 
 .nav-menu-toggle {
   width: 2.5rem;
+  display: none;
 }
 
 .toggle-btn:hover,
@@ -268,9 +269,6 @@ li {
   background: var(--clr-accent);
 }
 
-.nav-menu-toggle {
-  display: block;
-}
 
 .nav-menu-toggle:focus {
   outline: none;
@@ -645,6 +643,33 @@ body.dark .ops-modal {
 }
 
 /* ==================================== */
+@media (max-width: 768px) {
+  .nav-links {
+    position: fixed;
+    top: 0;
+    right: 0;
+    height: 100%;
+    width: 70%;
+    max-width: 300px;
+    display: flex;
+    flex-direction: column;
+    margin-top: 0;
+    background: var(--clr-background);
+    border-left: 1px solid var(--clr-form-border);
+    border-radius: 5px 0 0 5px;
+    transform: translateX(100%);
+    transition: transform 0.3s ease;
+    padding: var(--space-xl) var(--space-md);
+    z-index: 1000;
+  }
+  .nav-links.open {
+    transform: translateX(0);
+  }
+  .ops-nav {
+    overflow-x: auto;
+  }
+}
+
 /* 5. Responsive */
 /* ==================================== */
 @media (min-width: 500px) {

--- a/js/main.js
+++ b/js/main.js
@@ -245,12 +245,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     const langData = (typeof translations !== 'undefined' && translations[currentLanguage]) || {};
     const navLabel = langData[ariaKey] || 'Menu';
     navToggle.setAttribute('aria-label', navLabel);
-
-    const updateToggleVisibility = () => {
-      navToggle.style.display = window.innerWidth <= 768 ? 'block' : 'none';
-    };
-    updateToggleVisibility();
-    window.addEventListener('resize', updateToggleVisibility);
   }
   if (navToggle && navLinks) {
     let lastFocusedElement;

--- a/tests/chatbot-modal.test.js
+++ b/tests/chatbot-modal.test.js
@@ -229,6 +229,7 @@ function runScripts(context, files) {
 test('chatbot modal initializes and handlers work', async () => {
   const document = new Document();
   const window = { document };
+  window.innerWidth = 500;
   window.addEventListener = () => {};
   window.dispatchEvent = () => {};
   const context = vm.createContext({ window, document, console, setTimeout, fetch: null });
@@ -307,6 +308,7 @@ test('chatbot modal initializes and handlers work', async () => {
 test('chatbot not initialized when HTML missing', async () => {
   const document = new Document();
   const window = { document };
+  window.innerWidth = 500;
   window.addEventListener = () => {};
   window.dispatchEvent = () => {};
   const context = vm.createContext({ window, document, console, fetch: null, setTimeout });
@@ -331,6 +333,7 @@ test('chatbot not initialized when HTML missing', async () => {
 test('chatbot FAB click is idempotent', async () => {
   const document = new Document();
   const window = { document };
+  window.innerWidth = 500;
   window.addEventListener = () => {};
   window.dispatchEvent = () => {};
   const context = vm.createContext({ window, document, console, fetch: null, setTimeout });

--- a/tests/ui/nav_and_fab_layout.test.js
+++ b/tests/ui/nav_and_fab_layout.test.js
@@ -28,6 +28,7 @@ test('fab stack uses safe-area margins and button sizes', () => {
 test('fab stack renders buttons in order', () => {
   const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { runScripts: 'dangerously', url: 'http://localhost' });
   const { window } = dom;
+  Object.defineProperty(window, 'innerWidth', { value: 500, configurable: true });
   window.fetch = async () => ({ text: async () => '<div></div>' });
   const code = fs.readFileSync(path.join(root, 'cojoinlistener.js'), 'utf-8');
   window.eval(code);


### PR DESCRIPTION
## Summary
- Hide nav hamburger toggle in nav bar and keep it accessible via floating button
- Build floating action buttons only on small screens and wire menu FAB to side nav
- Add mobile-only media query for off-canvas nav links and update tests for new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689658eaf798832ba0184e35651045af