### PR TITLE
Ensure FAB stack stays visible across mobile viewports

### DIFF
--- a/contact-center.html
+++ b/contact-center.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha512-Fo3rlrZj/k7ujTnHg4CGR2D7kSs0v4LLanw2qksYuRlEzO+tcaEPQogQ0KaoGN26/zrn20ImR1DfuLWnOo7aBA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="fabs/css/cojoin.css">
   <link rel="stylesheet" href="fabs/css/chatbot.css">
+  <script src="js/viewport.js" defer></script>
   <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
 </head>
 <body class="page-contact-center">

--- a/css/style.css
+++ b/css/style.css
@@ -35,6 +35,8 @@
   --space-xl: 2.5rem;
   --space-2xl: 3.125rem;
   --space-3xl: 3.75rem;
+  /* Fallback viewport unit */
+  --vh: 1vh;
 }
 
 /* Dark Theme Variables */
@@ -78,7 +80,8 @@ body.dark {
 
 body {
   font-family: "Segoe UI", Arial, sans-serif;
-  min-height: 100dvh;
+  min-height: 100vh;
+  min-height: calc(var(--vh, 1vh) * 100);
   margin: 0;
   color: var(--clr-text-subtle);
   padding-top: env(safe-area-inset-top);
@@ -523,7 +526,8 @@ body.dark .card .icon > i {
   min-width: 19.375rem;
   max-width: 50rem;
   width: 80vw;
-  max-height: 80dvh;
+  max-height: 80vh;
+  max-height: calc(var(--vh, 1vh) * 80);
   background: #fff;
   color: #1a1930;
   border-radius: 2rem;

--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -7,6 +7,7 @@
   --clr-bg-dark:#121212;
   --clr-tx   :#333333;
   --clr-tx-dark:#f0f0f0;
+  --vh: 1vh;
 }
 body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
 
@@ -14,7 +15,8 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
 #chatbot-container{
   width: 90vw;
   max-width: 400px;
-  height: 90dvh;
+  height: 90vh;
+  height: calc(var(--vh, 1vh) * 90);
   max-height: 600px;
   background:#251541;
   border:0.125rem solid var(--clr-accent);
@@ -49,7 +51,8 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
 @media (max-width: 47.9375rem) {
   #chatbot-container {
     width: 100vw;
-    height: 100dvh;
+    height: 100vh;
+    height: calc(var(--vh, 1vh) * 100);
     border-radius: 0;
     top: 0;
     left: 0;

--- a/fabs/css/cojoin.css
+++ b/fabs/css/cojoin.css
@@ -5,6 +5,7 @@
   --clr-accent-dark: #e000be;
   --clr-bg: #fff;
   --clr-tx: #333;
+  --vh: 1vh;
 }
 
 /* Base Styles */
@@ -80,8 +81,10 @@ body[data-lock="true"] {
   transform: translate(-50%, -50%);
   width: 90vw;
   max-width: 600px;
-  height: 90dvh;
-  max-height: 90dvh;
+  height: 90vh;
+  height: calc(var(--vh, 1vh) * 90);
+  max-height: 90vh;
+  max-height: calc(var(--vh, 1vh) * 90);
   background: var(--clr-bg);
   border-radius: 0.75rem;
   box-shadow: 0 0.5rem 2rem rgba(0, 0, 0, 0.25);
@@ -96,7 +99,8 @@ body[data-lock="true"] {
     top: 0;
     left: 0;
     width: 100vw;
-    height: 100dvh;
+    height: 100vh;
+    height: calc(var(--vh, 1vh) * 100);
     max-width: none;
     max-height: none;
     top: 50%;

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha512-Fo3rlrZj/k7ujTnHg4CGR2D7kSs0v4LLanw2qksYuRlEzO+tcaEPQogQ0KaoGN26/zrn20ImR1DfuLWnOo7aBA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="fabs/css/cojoin.css">
   <link rel="stylesheet" href="fabs/css/chatbot.css">
+  <script src="js/viewport.js" defer></script>
   <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
 </head>
 <body class="page-business-ops">

--- a/it-support.html
+++ b/it-support.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha512-Fo3rlrZj/k7ujTnHg4CGR2D7kSs0v4LLanw2qksYuRlEzO+tcaEPQogQ0KaoGN26/zrn20ImR1DfuLWnOo7aBA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="fabs/css/cojoin.css">
   <link rel="stylesheet" href="fabs/css/chatbot.css">
+  <script src="js/viewport.js" defer></script>
   <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
 </head>
 <body class="page-it-support">

--- a/js/viewport.js
+++ b/js/viewport.js
@@ -1,0 +1,8 @@
+(function() {
+  function setVh() {
+    const vh = window.innerHeight * 0.01;
+    document.documentElement.style.setProperty('--vh', `${vh}px`);
+  }
+  setVh();
+  window.addEventListener('resize', setVh);
+})();

--- a/professional-services.html
+++ b/professional-services.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha512-Fo3rlrZj/k7ujTnHg4CGR2D7kSs0v4LLanw2qksYuRlEzO+tcaEPQogQ0KaoGN26/zrn20ImR1DfuLWnOo7aBA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="fabs/css/cojoin.css">
   <link rel="stylesheet" href="fabs/css/chatbot.css">
+  <script src="js/viewport.js" defer></script>
   <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
 </head>
 <body class="page-professional-services">


### PR DESCRIPTION
## Summary
- compute dynamic `--vh` CSS variable via new `viewport.js`
- rely on `--vh` for page and modal heights instead of `dvh`
- load viewport helper on all pages to keep FABs within view

## Testing
- `npm test`
- `npm run ci:test`


------
https://chatgpt.com/codex/tasks/task_e_6896606a09ec832b9cf63b1cbb86d922