### PR TITLE
Adjust modal container sizing

### DIFF
--- a/fabs/css/cojoin.css
+++ b/fabs/css/cojoin.css
@@ -78,10 +78,8 @@ body[data-lock="true"] {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 90vw;
-  max-width: 600px;
-  height: 90dvh;
-  max-height: 90dvh;
+  width: clamp(90vw, 91vw, 92vw);
+  height: 80dvh;
   background: var(--clr-bg);
   border-radius: 0.75rem;
   box-shadow: 0 0.5rem 2rem rgba(0, 0, 0, 0.25);
@@ -91,18 +89,17 @@ body[data-lock="true"] {
   overflow: hidden;
 }
 
-@media (max-width: 47.9375rem) {
+@media (min-width: 768px) {
   .modal-container {
-    top: 0;
-    left: 0;
+    width: clamp(70vw, 75vw, 80vw);
+    height: clamp(70dvh, 75dvh, 80dvh);
+  }
+}
+
+@media (max-height: 560px) {
+  .modal-container {
     width: 100vw;
     height: 100dvh;
-    max-width: none;
-    max-height: none;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    border-radius: 12px;
   }
 }
 


### PR DESCRIPTION
## Summary
- refine `.modal-container` sizing for mobile, tablet, and low-height screens

## Testing
- `npm test` *(fails: Cannot find module 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_689662818b2c832b95236f9b7e9044ba