### PR TITLE
Rename chatbot container and adjust responsive sizing

### DIFF
--- a/cojoinlistener.js
+++ b/cojoinlistener.js
@@ -104,7 +104,7 @@ document.addEventListener('DOMContentLoaded', () => {
    * @param {string} modalId 'contact', 'join', or 'chatbot'.
    */
   async function showModal(modalId) {
-    const targetId = modalId === 'chatbot' ? 'chatbot-container' : `${modalId}-modal`;
+    const targetId = modalId === 'chatbot' ? 'modal-chatbot' : `${modalId}-modal`;
     lastFocused = document.activeElement;
 
     if (activeModal && activeModal.id !== targetId) {
@@ -133,7 +133,7 @@ document.addEventListener('DOMContentLoaded', () => {
         template.innerHTML = sanitized;
 
         const root = template.content || template;
-        modal = root.querySelector('.modal-container') || root.querySelector('#chatbot-container');
+        modal = root.querySelector('.modal-container') || root.querySelector('#modal-chatbot');
         if (modal) {
           if (modalId !== 'chatbot') {
             modal.id = targetId;

--- a/fabs/chatbot.html
+++ b/fabs/chatbot.html
@@ -1,5 +1,5 @@
 <!-- This is a fragment, intended to be loaded dynamically -->
-<div id="chatbot-container" role="dialog" aria-modal="true" aria-labelledby="title">
+<div id="modal-chatbot" role="dialog" aria-modal="true" aria-labelledby="title">
   <div id="chatbot-header">
     <span id="title" data-en="Chattia" data-es="Chattia">Chattia</span>
 

--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -11,10 +11,10 @@
 body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
 
 /* ---------- CHATBOT ---------- */
-#chatbot-container{
-  width: 90vw;
+#modal-chatbot{
+  width: 75vw;
   max-width: 400px;
-  height: 90dvh;
+  height: 85dvh;
   max-height: 600px;
   background:#251541;
   border:0.125rem solid var(--clr-accent);
@@ -46,21 +46,31 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
   z-index: 1;
 }
 #chatbot-header #title{color:#000;}
-@media (max-width: 47.9375rem) {
-  #chatbot-container {
-    width: 100vw;
-    height: 100dvh;
-    border-radius: 0;
-    top: 0;
-    left: 0;
-    transform: none;
-    overflow-y: auto;
-    max-width: none;
-    max-height: none;
+@media (min-width:48rem) and (max-width:63.9375rem){
+  #modal-chatbot{
+    width:70vw;
+    height:75dvh;
   }
-  #chatbot-header {
-    cursor: default;
+}
+@media (max-width:47.9375rem){
+  #modal-chatbot{
+    width:85vw;
+    height:85dvh;
   }
+}
+@media (max-height:35rem){
+  #modal-chatbot{
+    width:100vw;
+    height:100dvh;
+    border-radius:0;
+    top:0;
+    left:0;
+    transform:none;
+    overflow-y:auto;
+    max-width:none;
+    max-height:none;
+  }
+  #chatbot-header{cursor:default;}
 }
 #chatbot-header .ctrl{cursor:pointer;font-size:.75rem;font-weight:500;user-select:none;opacity:.85}
 #chatbot-header .ctrl:hover{opacity:1}

--- a/fabs/js/chattia.js
+++ b/fabs/js/chattia.js
@@ -9,7 +9,7 @@ function initChatbot() {
   const qs = s => document.querySelector(s),
         qsa = s => [...document.querySelectorAll(s)];
 
-  const chatbotContainer = qs('#chatbot-container');
+  const chatbotContainer = qs('#modal-chatbot');
   if (!chatbotContainer) return;
 
   /* === Language toggle === */

--- a/tests/chatbot-modal.test.js
+++ b/tests/chatbot-modal.test.js
@@ -50,7 +50,7 @@ class Element {
   set innerHTML(html) {
     this._innerHTML = html;
     this.children = [];
-    if (html.includes('chatbot-container')) {
+    if (html.includes('modal-chatbot')) {
       const modal = createChatbotModal();
       modal.parentNode = this;
       this.children.push(modal);
@@ -147,7 +147,7 @@ function querySelectorFrom(root, selector, all) {
 
 function createChatbotModal() {
   const container = new Element('div');
-  container.id = 'chatbot-container';
+  container.id = 'modal-chatbot';
 
   const header = new Element('div');
   header.id = 'chatbot-header';
@@ -236,7 +236,7 @@ test('chatbot modal initializes and handlers work', async () => {
   context.window.initDraggableModal = () => {};
 
   // fetch stub for modal and chat responses
-  const chatbotHtml = '<div id="chatbot-container"></div>';
+  const chatbotHtml = '<div id="modal-chatbot"></div>';
   context.fetch = async (url) => {
     if (url.endsWith('chatbot.html')) {
       return { text: async () => chatbotHtml };
@@ -340,7 +340,7 @@ test('chatbot FAB click is idempotent', async () => {
   context.window.initDraggableModal = () => {};
 
   // fetch stub for modal and chat responses
-  const chatbotHtml = '<div id="chatbot-container"></div>';
+  const chatbotHtml = '<div id="modal-chatbot"></div>';
   context.fetch = async (url) => ({ text: async () => chatbotHtml });
 
   // Load scripts
@@ -365,7 +365,7 @@ test('chatbot FAB click is idempotent', async () => {
   assert.strictEqual(count, 1, 'initChatbot only called once');
 
   // Ensure only one chatbot container exists
-  const containers = document.querySelectorAll('#chatbot-container');
+  const containers = document.querySelectorAll('#modal-chatbot');
   assert.strictEqual(containers.length, 1, 'only one chatbot container appended');
 });
 


### PR DESCRIPTION
## Summary
- rename chatbot container to `modal-chatbot` in HTML and scripts
- refine chatbot modal responsive dimensions for mobile, tablet, and small-height fallbacks
- update tests to align with new container ID

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689662970514832bb5ec605581bdcced