### PR TITLE
Align FAB stack safe-area offsets

### DIFF
--- a/fabs/css/cojoin.css
+++ b/fabs/css/cojoin.css
@@ -23,8 +23,8 @@ body {
 /* Floating Action Button (FAB) Stack */
 .fab-stack {
   position: fixed;
-  bottom: calc(env(safe-area-inset-bottom) + 20px);
-  right: calc(env(safe-area-inset-right) + 10px);
+  bottom: calc(env(safe-area-inset-bottom) + 16px);
+  right: calc(env(safe-area-inset-right) + 16px);
   z-index: 1000;
   display: flex;
   flex-direction: column;

--- a/tests/ui/nav_and_fab_layout.test.js
+++ b/tests/ui/nav_and_fab_layout.test.js
@@ -13,8 +13,8 @@ test('fab stack uses safe-area margins and button sizes', () => {
   assert.ok(stackMatch, 'fab-stack styles not found');
   const stackBlock = stackMatch[0];
   assert.ok(/position:\s*fixed/.test(stackBlock), 'fab stack should be fixed');
-  assert.ok(/bottom:\s*calc\(env\(safe-area-inset-bottom\) \+ 20px\)/.test(stackBlock), 'bottom margin should use safe-area inset');
-  assert.ok(/right:\s*calc\(env\(safe-area-inset-right\) \+ 10px\)/.test(stackBlock), 'right margin should use safe-area inset');
+  assert.ok(/bottom:\s*calc\(env\(safe-area-inset-bottom\) \+ 16px\)/.test(stackBlock), 'bottom margin should use safe-area inset');
+  assert.ok(/right:\s*calc\(env\(safe-area-inset-right\) \+ 16px\)/.test(stackBlock), 'right margin should use safe-area inset');
 
   const btnMatch = css.match(/\.fab-stack__button\s*{[\s\S]*?}/);
   assert.ok(btnMatch, 'fab-stack__button styles not found');


### PR DESCRIPTION
## Summary
- align FAB stack spacing with mobile safe-area insets using 16px offsets for bottom and right
- update layout test for new FAB stack offsets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689663037a6c832bb868c1fdd0a967e7