### PR TITLE
Respect reduced-motion preferences

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -530,7 +530,7 @@ body.dark .card .icon > i {
   border: 0.0625rem solid rgba(0, 0, 0, 0.1);
   box-shadow: 0 0.25rem 1.25rem rgba(0, 0, 0, 0.15);
   padding: 2.1rem 2.2rem 1.3rem 2.2rem;
-  transition: box-shadow 0.17s;
+  transition: box-shadow 0.25s;
   cursor: default;
   z-index: 3000;
   display: flex;
@@ -608,7 +608,7 @@ body.dark .ops-modal {
   cursor: pointer;
   font-weight: 600;
   margin-top: 0.5em;
-  transition: background 0.17s;
+  transition: background 0.25s;
   width: 100%;
 }
 
@@ -760,5 +760,15 @@ body.dark .ops-modal {
   0% { background-position: 0% 50%; }
   50% { background-position: 100% 50%; }
   100% { background-position: 0% 50%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+  body {
+    animation: none !important;
+  }
 }
 

--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -93,3 +93,10 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
 #chatbot-close{margin-left:0}
 .human-check{color:#ddd;font-size:.85rem;display:flex;align-items:center;margin-top:.3rem}
 .human-check input{margin-right:.4rem}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/fabs/css/cojoin.css
+++ b/fabs/css/cojoin.css
@@ -285,3 +285,10 @@ button.submit-btn:hover {
 .honeypot {
   display: none !important;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
- honor user reduced-motion settings by disabling animations and transitions across site styles
- standardize modal transitions to 250ms for accessible timing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896631562b4832bb6360ff4ac58013b