### PR TITLE
feat: add responsive nav heights

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -162,7 +162,8 @@ li {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1.2rem 2rem;
+  height: 64px;
+  padding: 0 2rem;
   padding-left: calc(2rem + env(safe-area-inset-left));
   padding-right: calc(2rem + env(safe-area-inset-right));
   font-weight: 600;
@@ -646,7 +647,7 @@ body.dark .ops-modal {
 }
 
 /* ==================================== */
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .nav-links {
     position: fixed;
     top: 0;
@@ -670,6 +671,10 @@ body.dark .ops-modal {
   }
   .ops-nav {
     overflow-x: auto;
+    height: 56px;
+    padding: 0 1.5rem;
+    padding-left: calc(1.5rem + env(safe-area-inset-left));
+    padding-right: calc(1.5rem + env(safe-area-inset-right));
   }
 }
 


### PR DESCRIPTION
## Summary
- enforce a 64px height for the main navigation bar and remove vertical padding
- ensure mobile navigation height is 56px with adjusted padding via `@media (max-width: 767px)`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896631a4848832b9e436c95c1ed4f3a