### PR TITLE
Enforce secure cookies and HTTPS in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,9 @@ served correctly.
 
 Operational policies for mobile and tablet platforms are documented in the [OPS Mobile & Tablet Annex v1.1](docs/OPS-Mobile-Tablet-Annex.md).
 
+## Local Development
+
+The server enforces HTTPS and sets `cookie.secure` when `NODE_ENV=production`.
+For local development over HTTP, set `NODE_ENV=development` before starting the
+server to disable HTTPS redirection and allow non-secure cookies.
+

--- a/server.js
+++ b/server.js
@@ -3,6 +3,18 @@ const session = require('express-session');
 const crypto = require('crypto');
 
 const app = express();
+const isProduction = process.env.NODE_ENV === 'production';
+
+// Enforce HTTPS and secure cookies in production. During local development,
+// set NODE_ENV=development to disable these checks.
+if (isProduction) {
+  app.use((req, res, next) => {
+    if (req.headers['x-forwarded-proto'] !== 'https') {
+      return res.redirect(`https://${req.headers.host}${req.url}`);
+    }
+    next();
+  });
+}
 
 app.use(express.json());
 app.use(
@@ -13,7 +25,7 @@ app.use(
     cookie: {
       httpOnly: true,
       sameSite: 'strict',
-      secure: false,
+      secure: isProduction,
     },
   })
 );

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,66 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+let missingDeps = false;
+try {
+  require.resolve('express');
+  require.resolve('express-session');
+} catch (err) {
+  missingDeps = true;
+}
+
+if (missingDeps) {
+  test.skip('express and express-session must be installed for server tests');
+} else {
+  // Helper to start server with specific NODE_ENV
+  async function withServer(env, fn) {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = env;
+    const serverPath = require.resolve('../server');
+    delete require.cache[serverPath];
+    const app = require('../server');
+    const server = app.listen(0);
+    await new Promise((resolve) => server.once('listening', resolve));
+    try {
+      await fn(server);
+    } finally {
+      await new Promise((resolve) => server.close(resolve));
+      delete require.cache[serverPath];
+      process.env.NODE_ENV = originalEnv;
+    }
+  }
+
+  test('environment-specific HTTPS enforcement and cookie security', async (t) => {
+    await t.test('production enforces HTTPS and secure cookies', async () => {
+      await withServer('production', async (server) => {
+        const port = server.address().port;
+
+        const secureRes = await fetch(`http://localhost:${port}/api/csrf-token`, {
+          headers: { 'x-forwarded-proto': 'https' },
+        });
+        const secureCookie = secureRes.headers.get('set-cookie');
+        assert.ok(secureCookie && secureCookie.includes('Secure'));
+
+        const redirectRes = await fetch(`http://localhost:${port}/api/csrf-token`, {
+          redirect: 'manual',
+        });
+        assert.strictEqual(redirectRes.status, 302);
+        assert.ok(redirectRes.headers.get('location').startsWith('https://'));
+      });
+    });
+
+    await t.test('development allows HTTP and insecure cookies', async () => {
+      await withServer('development', async (server) => {
+        const port = server.address().port;
+
+        const res = await fetch(`http://localhost:${port}/api/csrf-token`, {
+          redirect: 'manual',
+        });
+        const cookie = res.headers.get('set-cookie');
+        assert.ok(cookie && !cookie.includes('Secure'));
+        assert.strictEqual(res.status, 200);
+      });
+    });
+  });
+}
+


### PR DESCRIPTION
## Summary
- enforce HTTPS redirection and secure session cookies when `NODE_ENV=production`
- document how to disable HTTPS and secure cookies for local development

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68966322849c832bbdb9ddf4aa531701