### PR TITLE
Remove language toggle styles

### DIFF
--- a/contact-center.html
+++ b/contact-center.html
@@ -9,10 +9,6 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha512-Fo3rlrZj/k7ujTnHg4CGR2D7kSs0v4LLanw2qksYuRlEzO+tcaEPQogQ0KaoGN26/zrn20ImR1DfuLWnOo7aBA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="fabs/css/cojoin.css">
   <link rel="stylesheet" href="fabs/css/chatbot.css">
-  <style>
-    [data-lang="en"] [data-es],
-    [data-lang="es"] [data-en] { display: none; }
-  </style>
   <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
 </head>
 <body class="page-contact-center">

--- a/index.html
+++ b/index.html
@@ -9,10 +9,6 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha512-Fo3rlrZj/k7ujTnHg4CGR2D7kSs0v4LLanw2qksYuRlEzO+tcaEPQogQ0KaoGN26/zrn20ImR1DfuLWnOo7aBA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="fabs/css/cojoin.css">
   <link rel="stylesheet" href="fabs/css/chatbot.css">
-  <style>
-    [data-lang="en"] [data-es],
-    [data-lang="es"] [data-en] { display: none; }
-  </style>
   <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
 </head>
 <body class="page-business-ops">

--- a/it-support.html
+++ b/it-support.html
@@ -9,10 +9,6 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha512-Fo3rlrZj/k7ujTnHg4CGR2D7kSs0v4LLanw2qksYuRlEzO+tcaEPQogQ0KaoGN26/zrn20ImR1DfuLWnOo7aBA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="fabs/css/cojoin.css">
   <link rel="stylesheet" href="fabs/css/chatbot.css">
-  <style>
-    [data-lang="en"] [data-es],
-    [data-lang="es"] [data-en] { display: none; }
-  </style>
   <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
 </head>
 <body class="page-it-support">

--- a/professional-services.html
+++ b/professional-services.html
@@ -9,10 +9,6 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha512-Fo3rlrZj/k7ujTnHg4CGR2D7kSs0v4LLanw2qksYuRlEzO+tcaEPQogQ0KaoGN26/zrn20ImR1DfuLWnOo7aBA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="fabs/css/cojoin.css">
   <link rel="stylesheet" href="fabs/css/chatbot.css">
-  <style>
-    [data-lang="en"] [data-es],
-    [data-lang="es"] [data-en] { display: none; }
-  </style>
   <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
 </head>
 <body class="page-professional-services">


### PR DESCRIPTION
## Summary
- remove language-specific display style blocks from index, contact-center, it-support, professional-services pages

## Testing
- `npm test` *(fails: page and modal styles rely on --vh variable)*
- `npm run ci:test`


------
https://chatgpt.com/codex/tasks/task_e_68966b12a030832b96caf0ed8069cd08