### PR TITLE
Refactor modal styling to use classes

### DIFF
--- a/cojoinlistener.js
+++ b/cojoinlistener.js
@@ -118,7 +118,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     let modal = document.getElementById(targetId);
     if (modal) {
-      modal.style.display = 'flex';
+      modal.classList.add('is-visible');
       activeModal = modal;
     } else {
       try {
@@ -148,7 +148,7 @@ document.addEventListener('DOMContentLoaded', () => {
               console.error('initCojoinForms failed:', err);
             }
           }
-          modal.style.display = 'flex';
+          modal.classList.add('is-visible');
           activeModal = modal;
 
           const closeBtn = modal.querySelector('.modal-close');
@@ -194,7 +194,7 @@ document.addEventListener('DOMContentLoaded', () => {
    */
   function hideModal(modal) {
     if (modal) {
-      modal.style.display = 'none';
+      modal.classList.remove('is-visible');
       activeModal = null;
     }
     removeOverlay();

--- a/fabs/contact.html
+++ b/fabs/contact.html
@@ -46,7 +46,7 @@
         </div>
       </div>
 
-      <div style="margin-top:1rem;">
+      <div class="mt-1">
         <label for="comments">Comments</label>
         <textarea id="comments" name="comments" rows="4" placeholder="What service are you interested in?"></textarea>
       </div>

--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -15,7 +15,7 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
 #modal-chatbot{
   width: 90vw;
   max-width: 400px;
-  height: 85dvh;
+  height: calc(var(--vh, 1vh) * 90);
   max-height: 600px;
   background:#251541;
   border:0.125rem solid var(--clr-accent);
@@ -50,7 +50,7 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
 @media (max-width: 47.9375rem) {
   #modal-chatbot {
     width: 100vw;
-    height: 100dvh;
+    height: calc(var(--vh, 1vh) * 100);
     border-radius: 0;
     top: 0;
     left: 0;
@@ -63,13 +63,13 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
 @media (max-width:47.9375rem){
   #modal-chatbot{
     width:85vw;
-    height:85dvh;
+    height: calc(var(--vh, 1vh) * 90);
   }
 }
 @media (max-height:35rem){
   #modal-chatbot{
     width:100vw;
-    height:100dvh;
+    height: calc(var(--vh, 1vh) * 100);
     border-radius:0;
     top:0;
     left:0;

--- a/fabs/css/cojoin.css
+++ b/fabs/css/cojoin.css
@@ -21,6 +21,15 @@ body {
   color: var(--clr-tx);
 }
 
+/* Utility classes */
+.hidden {
+  display: none !important;
+}
+
+.mt-1 {
+  margin-top: 1rem;
+}
+
 /* Floating Action Button (FAB) Stack */
 .fab-stack {
   position: fixed;
@@ -80,7 +89,7 @@ body[data-lock="true"] {
   left: 50%;
   transform: translate(-50%, -50%);
   width: clamp(90vw, 91vw, 92vw);
-  height: 80dvh;
+  height: calc(var(--vh, 1vh) * 90);
   background: var(--clr-bg);
   border-radius: 0.75rem;
   box-shadow: 0 0.5rem 2rem rgba(0, 0, 0, 0.25);
@@ -88,6 +97,20 @@ body[data-lock="true"] {
   flex-direction: column;
   z-index: 1001;
   overflow: hidden;
+  transition: transform 0.3s ease;
+}
+
+.modal-container.is-visible {
+  display: flex;
+}
+
+.modal-container.dragging {
+  cursor: grabbing;
+  transition: none;
+}
+
+.modal-container.is-dragged {
+  transform: none;
 }
 
 @media (min-width: 768px) {
@@ -100,7 +123,7 @@ body[data-lock="true"] {
 @media (max-height: 560px) {
   .modal-container {
     width: 100vw;
-    height: 100dvh;
+    height: calc(var(--vh, 1vh) * 100);
   }
 }
 

--- a/fabs/join.html
+++ b/fabs/join.html
@@ -34,7 +34,7 @@
         </div>
         <div class="inputs"></div>
         <button type="button" class="accept-btn">Accept</button>
-        <button type="button" class="edit-btn" style="display:none;">Edit</button>
+        <button type="button" class="edit-btn hidden">Edit</button>
       </div>
 
       <div class="form-section" data-section="Education">
@@ -47,7 +47,7 @@
         </div>
         <div class="inputs"></div>
         <button type="button" class="accept-btn">Accept</button>
-        <button type="button" class="edit-btn" style="display:none;">Edit</button>
+        <button type="button" class="edit-btn hidden">Edit</button>
       </div>
 
       <div class="form-section" data-section="Certification">
@@ -60,7 +60,7 @@
         </div>
         <div class="inputs"></div>
         <button type="button" class="accept-btn">Accept</button>
-        <button type="button" class="edit-btn" style="display:none;">Edit</button>
+        <button type="button" class="edit-btn hidden">Edit</button>
       </div>
 
       <div class="form-section" data-section="Hobbies">
@@ -73,7 +73,7 @@
         </div>
         <div class="inputs"></div>
         <button type="button" class="accept-btn">Accept</button>
-        <button type="button" class="edit-btn" style="display:none;">Edit</button>
+        <button type="button" class="edit-btn hidden">Edit</button>
       </div>
 
       <div class="form-section">
@@ -97,7 +97,7 @@
         </div>
         <div class="inputs"></div>
         <button type="button" class="accept-btn">Accept</button>
-        <button type="button" class="edit-btn" style="display:none;">Edit</button>
+        <button type="button" class="edit-btn hidden">Edit</button>
       </div>
 
       <div class="form-section" data-section="Experience">
@@ -110,7 +110,7 @@
         </div>
         <div class="inputs"></div>
         <button type="button" class="accept-btn">Accept</button>
-        <button type="button" class="edit-btn" style="display:none;">Edit</button>
+        <button type="button" class="edit-btn hidden">Edit</button>
       </div>
 
       <div>

--- a/fabs/js/cojoin.js
+++ b/fabs/js/cojoin.js
@@ -56,8 +56,7 @@ function initCojoinForms() {
       isDragging = true;
       offsetX = e.clientX - modal.getBoundingClientRect().left;
       offsetY = e.clientY - modal.getBoundingClientRect().top;
-      modal.style.cursor = 'grabbing';
-      modal.style.transition = 'none'; // Disable transition while dragging
+      modal.classList.add('dragging', 'is-dragged');
     });
 
     document.addEventListener('mousemove', (e) => {
@@ -69,13 +68,11 @@ function initCojoinForms() {
 
       modal.style.left = `${newX}px`;
       modal.style.top = `${newY}px`;
-      modal.style.transform = 'none';
     });
 
     document.addEventListener('mouseup', () => {
       isDragging = false;
-      modal.style.cursor = 'move';
-      modal.style.transition = 'transform 0.3s ease'; // Re-enable transition
+      modal.classList.remove('dragging');
     });
   }
 
@@ -394,14 +391,14 @@ function initCojoinForms() {
     inputs.forEach(input => input.disabled = accepted);
 
     if (accepted) {
-      if (acceptBtn) acceptBtn.style.display = 'none';
-      if (editBtn) editBtn.style.display = 'inline-block';
+      if (acceptBtn) acceptBtn.classList.add('hidden');
+      if (editBtn) editBtn.classList.remove('hidden');
       if (addBtn) addBtn.disabled = true;
       if (removeBtn) removeBtn.disabled = true;
       section.classList.add('completed');
     } else {
-      if (acceptBtn) acceptBtn.style.display = 'inline-block';
-      if (editBtn) editBtn.style.display = 'none';
+      if (acceptBtn) acceptBtn.classList.remove('hidden');
+      if (editBtn) editBtn.classList.add('hidden');
       if (addBtn) addBtn.disabled = false;
       if (removeBtn) removeBtn.disabled = false;
       section.classList.remove('completed');


### PR DESCRIPTION
## Summary
- Replace inline modal styles with `.mt-1` and `.hidden` classes
- Toggle modal visibility and join form controls via classList instead of inline styles
- Add utility and viewport-based CSS rules for modals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689673bd663c832bb1f7f70ec7f9eac4