### PR TITLE
fix: stop draggable headers from hijacking close clicks

### DIFF
--- a/fabs/js/cojoin.js
+++ b/fabs/js/cojoin.js
@@ -53,6 +53,11 @@ function initCojoinForms() {
     if (!modalHeader) return;
 
     modalHeader.addEventListener('mousedown', (e) => {
+      // Ignore drag initiation when interacting with buttons or form controls
+      if (e.target.closest('button, [href], input, select, textarea')) {
+        return;
+      }
+
       isDragging = true;
       offsetX = e.clientX - modal.getBoundingClientRect().left;
       offsetY = e.clientY - modal.getBoundingClientRect().top;

--- a/js/main.js
+++ b/js/main.js
@@ -74,6 +74,11 @@ function makeDraggable(modal) {
   let isDragging = false;
   let offsetX, offsetY;
   header.addEventListener('mousedown', (e) => {
+    // Skip dragging when interacting with buttons or other controls
+    if (e.target.closest('button, [href], input, select, textarea')) {
+      return;
+    }
+
     isDragging = true;
 
     // We calculate the offset from the top-left of the modal.

--- a/tests/assets-functions.test.js
+++ b/tests/assets-functions.test.js
@@ -88,7 +88,7 @@ test('makeDraggable updates modal position on drag', () => {
   makeDraggable(modal);
   assert.strictEqual(typeof header.events.mousedown, 'function');
 
-  header.events.mousedown({ clientX: 10, clientY: 10 });
+  header.events.mousedown({ clientX: 10, clientY: 10, target: { closest: () => null } });
   documentStub._events.mousemove({ clientX: 30, clientY: 40, preventDefault() {} });
   assert.strictEqual(modal.style.transform, 'none');
   assert.strictEqual(modal.style.left, '20px');
@@ -96,4 +96,25 @@ test('makeDraggable updates modal position on drag', () => {
 
   documentStub._events.mouseup();
   assert.ok(!documentStub._events.mousemove);
+});
+
+test('makeDraggable ignores mousedown on interactive elements', () => {
+  // Reset event registry
+  for (const k in documentStub._events) {
+    delete documentStub._events[k];
+  }
+
+  const header = { events: {}, addEventListener(type, handler) { this.events[type] = handler; } };
+  const modal = {
+    offsetLeft: 0,
+    offsetTop: 0,
+    style: {},
+    querySelector(sel) { return sel === '.modal-header' ? header : null; }
+  };
+
+  makeDraggable(modal);
+  const btn = { closest: sel => (sel.includes('button') ? btn : null) };
+  header.events.mousedown({ clientX: 10, clientY: 10, target: btn });
+
+  assert.ok(!documentStub._events.mousemove, 'mousemove listener should not be registered');
 });


### PR DESCRIPTION
## Summary
- ignore mousedown on buttons and form controls when starting modal drag
- extend draggable helper to respect interactive elements
- cover draggable helper with test for control click behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68967ffe97fc832bb0ab77dc55a41d90