### PR TITLE
Fix chatbot FAB not showing modal

### DIFF
--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -31,6 +31,10 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
   z-index: 1001;
   display: none;
 }
+
+#modal-chatbot.is-visible {
+  display: flex;
+}
 #chatbot-header{
   display:flex;
   justify-content:space-between;

--- a/tests/viewport.test.js
+++ b/tests/viewport.test.js
@@ -36,6 +36,7 @@ test('page and modal styles rely on --vh variable', () => {
   const chatbotCss = fs.readFileSync(path.join(root, 'fabs', 'css', 'chatbot.css'), 'utf8');
   assert.ok(/height:\s*calc\(var\(--vh, 1vh\) \* 90\)/.test(chatbotCss), 'chatbot modal should use --vh');
   assert.ok(/height:\s*calc\(var\(--vh, 1vh\) \* 100\)/.test(chatbotCss), 'chatbot modal should expand using --vh on mobile');
+  assert.ok(/#modal-chatbot\.is-visible\s*{[\s\S]*display\s*:\s*flex/.test(chatbotCss), 'chatbot modal should display when visible');
 
   const cojoinCss = fs.readFileSync(path.join(root, 'fabs', 'css', 'cojoin.css'), 'utf8');
   assert.ok(/height:\s*calc\(var\(--vh, 1vh\) \* 90\)/.test(cojoinCss), 'cojoin modal should use --vh');


### PR DESCRIPTION
## Summary
- ensure chatbot modal is displayed when `is-visible` is set
- test CSS for visible chatbot modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689680f3a92c832b9665c6c5c54ca97a