### PR TITLE
Only mark modals as dragged after movement

### DIFF
--- a/fabs/js/cojoin.js
+++ b/fabs/js/cojoin.js
@@ -70,8 +70,10 @@ function initCojoinForms() {
       if (!isDragging) return;
       e.preventDefault();
 
-      hasMoved = true;
-      modal.classList.add('is-dragged');
+      if (!hasMoved) {
+        hasMoved = true;
+        modal.classList.add('is-dragged');
+      }
 
       const newX = e.clientX - offsetX;
       const newY = e.clientY - offsetY;

--- a/fabs/js/cojoin.js
+++ b/fabs/js/cojoin.js
@@ -47,6 +47,7 @@ function initCojoinForms() {
     }
 
     let isDragging = false;
+    let hasMoved = false;
     let offsetX, offsetY;
 
     const modalHeader = modal.querySelector('.modal__header') || modal.querySelector('#chatbot-header');
@@ -59,14 +60,18 @@ function initCojoinForms() {
       }
 
       isDragging = true;
+      hasMoved = false;
       offsetX = e.clientX - modal.getBoundingClientRect().left;
       offsetY = e.clientY - modal.getBoundingClientRect().top;
-      modal.classList.add('dragging', 'is-dragged');
+      modal.classList.add('dragging');
     });
 
     document.addEventListener('mousemove', (e) => {
       if (!isDragging) return;
       e.preventDefault();
+
+      hasMoved = true;
+      modal.classList.add('is-dragged');
 
       const newX = e.clientX - offsetX;
       const newY = e.clientY - offsetY;
@@ -78,6 +83,10 @@ function initCojoinForms() {
     document.addEventListener('mouseup', () => {
       isDragging = false;
       modal.classList.remove('dragging');
+      if (!hasMoved) {
+        modal.classList.remove('is-dragged');
+      }
+      hasMoved = false;
     });
   }
 


### PR DESCRIPTION
## Summary
- track cursor movement in draggable modals
- defer `is-dragged` addition until cursor moves
- reset dragging state when the mouse is released

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896f0c05d9c832b807ec353a8fcc790