### PR TITLE
feat: guard draggable initialization

### DIFF
--- a/fabs/js/cojoin.js
+++ b/fabs/js/cojoin.js
@@ -39,8 +39,9 @@ function initCojoinForms() {
   /**
    * Enables draggable functionality for modals on large screens.
    * @param {HTMLElement} modal The modal element to make draggable.
-   */
+  */
   function makeDraggable(modal) {
+    if (modal.dataset.draggableInit) return;
     // Only make draggable on larger screens where there is enough space.
     if (window.innerWidth < 768) {
       return;
@@ -52,7 +53,7 @@ function initCojoinForms() {
     const modalHeader = modal.querySelector('.modal__header') || modal.querySelector('#chatbot-header');
     if (!modalHeader) return;
 
-    modalHeader.addEventListener('mousedown', (e) => {
+    modalHeader.addEventListener('pointerdown', (e) => {
       // Ignore drag initiation when interacting with buttons or form controls
       if (e.target.closest('button, [href], input, select, textarea')) {
         return;
@@ -62,9 +63,11 @@ function initCojoinForms() {
       offsetX = e.clientX - modal.getBoundingClientRect().left;
       offsetY = e.clientY - modal.getBoundingClientRect().top;
       modal.classList.add('dragging', 'is-dragged');
+      document.addEventListener('pointermove', onPointerMove);
+      document.addEventListener('pointerup', onPointerUp);
     });
 
-    document.addEventListener('mousemove', (e) => {
+    function onPointerMove(e) {
       if (!isDragging) return;
       e.preventDefault();
 
@@ -73,12 +76,16 @@ function initCojoinForms() {
 
       modal.style.left = `${newX}px`;
       modal.style.top = `${newY}px`;
-    });
+    }
 
-    document.addEventListener('mouseup', () => {
+    function onPointerUp() {
       isDragging = false;
       modal.classList.remove('dragging');
-    });
+      document.removeEventListener('pointermove', onPointerMove);
+      document.removeEventListener('pointerup', onPointerUp);
+    }
+
+    modal.dataset.draggableInit = 'true';
   }
 
   // Expose the draggable function globally for use by the listener script

--- a/js/main.js
+++ b/js/main.js
@@ -69,11 +69,12 @@ function createModal(serviceKey, lang) {
 }
 
 function makeDraggable(modal) {
+  if (modal.dataset.draggableInit) return;
   const header = modal.querySelector('.modal-header');
   if (!header) return;
   let isDragging = false;
   let offsetX, offsetY;
-  header.addEventListener('mousedown', (e) => {
+  header.addEventListener('pointerdown', (e) => {
     // Skip dragging when interacting with buttons or other controls
     if (e.target.closest('button, [href], input, select, textarea')) {
       return;
@@ -91,10 +92,10 @@ function makeDraggable(modal) {
 
     // We add the listeners to the document so that dragging continues
     // even if the cursor moves outside the modal header.
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
+    document.addEventListener('pointermove', onPointerMove);
+    document.addEventListener('pointerup', onPointerUp);
   });
-  function onMouseMove(e) {
+  function onPointerMove(e) {
     if (!isDragging) return;
 
     // Prevent text selection during drag
@@ -105,11 +106,13 @@ function makeDraggable(modal) {
     modal.style.top = `${newY}px`;
   }
 
-  function onMouseUp() {
+  function onPointerUp() {
     isDragging = false;
-    document.removeEventListener('mousemove', onMouseMove);
-    document.removeEventListener('mouseup', onMouseUp);
+    document.removeEventListener('pointermove', onPointerMove);
+    document.removeEventListener('pointerup', onPointerUp);
   }
+
+  modal.dataset.draggableInit = 'true';
 }
 
 // Export the draggable helper for other modules

--- a/tests/assets-functions.test.js
+++ b/tests/assets-functions.test.js
@@ -82,20 +82,27 @@ test('makeDraggable updates modal position on drag', () => {
     offsetLeft: 0,
     offsetTop: 0,
     style: {},
+    dataset: {},
     querySelector(sel) { return sel === '.modal-header' ? header : null; }
   };
 
   makeDraggable(modal);
-  assert.strictEqual(typeof header.events.mousedown, 'function');
+  assert.strictEqual(typeof header.events.pointerdown, 'function');
+  assert.strictEqual(modal.dataset.draggableInit, 'true');
 
-  header.events.mousedown({ clientX: 10, clientY: 10, target: { closest: () => null } });
-  documentStub._events.mousemove({ clientX: 30, clientY: 40, preventDefault() {} });
+  // Second initialization should be skipped
+  const initialHandler = header.events.pointerdown;
+  makeDraggable(modal);
+  assert.strictEqual(header.events.pointerdown, initialHandler);
+
+  header.events.pointerdown({ clientX: 10, clientY: 10, target: { closest: () => null } });
+  documentStub._events.pointermove({ clientX: 30, clientY: 40, preventDefault() {} });
   assert.strictEqual(modal.style.transform, 'none');
   assert.strictEqual(modal.style.left, '20px');
   assert.strictEqual(modal.style.top, '30px');
 
-  documentStub._events.mouseup();
-  assert.ok(!documentStub._events.mousemove);
+  documentStub._events.pointerup();
+  assert.ok(!documentStub._events.pointermove);
 });
 
 test('makeDraggable ignores mousedown on interactive elements', () => {
@@ -109,12 +116,13 @@ test('makeDraggable ignores mousedown on interactive elements', () => {
     offsetLeft: 0,
     offsetTop: 0,
     style: {},
+    dataset: {},
     querySelector(sel) { return sel === '.modal-header' ? header : null; }
   };
 
   makeDraggable(modal);
   const btn = { closest: sel => (sel.includes('button') ? btn : null) };
-  header.events.mousedown({ clientX: 10, clientY: 10, target: btn });
+  header.events.pointerdown({ clientX: 10, clientY: 10, target: btn });
 
-  assert.ok(!documentStub._events.mousemove, 'mousemove listener should not be registered');
+  assert.ok(!documentStub._events.pointermove, 'pointermove listener should not be registered');
 });


### PR DESCRIPTION
## Summary
- prevent duplicate modal dragging setup with a dataset guard and pointer events
- update modal dragging util in cojoin scripts to mirror guard logic
- refresh tests for pointer events and single init

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896f0c574d8832bbed8b324063887c6