### PR TITLE
Ensure menu FAB and nav toggle stay in sync

### DIFF
--- a/cojoinlistener.js
+++ b/cojoinlistener.js
@@ -39,22 +39,30 @@ document.addEventListener('DOMContentLoaded', () => {
     const contactFab = createFab('contact', '<i class="fa fa-envelope"></i>', 'Contact Us', 'fab--contact');
     const joinFab = createFab('join', '<i class="fa fa-user-plus"></i>', 'Join Us', 'fab--join');
     const chatbotFab = createFab('chatbot', '<i class="fa fa-comments"></i>', 'Chatbot', 'fab--chatbot');
-    const menuFab = createFab('menu', '<i class="fa fa-bars"></i>', 'Menu', 'fab--menu');
+    const navToggle = document.querySelector('.nav-menu-toggle');
+    let menuFab;
+    if (navToggle) {
+      menuFab = createFab('menu', '<i class="fa fa-bars"></i>', 'Menu', 'fab--menu');
+    }
 
     fabStack.appendChild(contactFab);
     fabStack.appendChild(joinFab);
     fabStack.appendChild(chatbotFab);
-    fabStack.appendChild(menuFab);
+    if (menuFab) {
+      fabStack.appendChild(menuFab);
+    }
 
     contactFab.addEventListener('click', () => showModal('contact'));
     joinFab.addEventListener('click', () => showModal('join'));
     chatbotFab.addEventListener('click', () => showModal('chatbot'));
-    menuFab.addEventListener('click', () => {
-      const navToggle = document.querySelector('.nav-menu-toggle');
-      if (navToggle && navToggle.click) {
-        navToggle.click();
-      }
-    });
+    if (menuFab) {
+      menuFab.addEventListener('click', () => {
+        const navToggle = document.querySelector('.nav-menu-toggle');
+        if (navToggle && navToggle.click) {
+          navToggle.click();
+        }
+      });
+    }
   }
 
   function checkFabVisibility() {

--- a/css/style.css
+++ b/css/style.css
@@ -737,9 +737,6 @@ body.dark .ops-modal {
   .nav-link:last-child {
     border-bottom: none;
   }
-  .nav-menu-toggle {
-    display: none;
-  }
   .nav-backdrop {
     display: none;
   }

--- a/tests/mobile-nav.test.js
+++ b/tests/mobile-nav.test.js
@@ -21,13 +21,18 @@ test('mobile nav links use off-canvas layout', () => {
   assert.ok(openMatch, 'nav links should slide in when open');
 });
 
-test('ops-nav enables horizontal scrolling when cramped', () => {
-  const css = fs.readFileSync(path.join(root, 'css', 'style.css'), 'utf-8');
-  const navMatch = css.match(/\.ops-nav\s*{[\s\S]*?}/);
-  assert.ok(navMatch, '.ops-nav rules for mobile not found');
-  const navBlock = navMatch[0];
-  assert.ok(navBlock.includes('overflow-x: auto'), '.ops-nav should allow horizontal scrolling');
-});
+  test('ops-nav enables horizontal scrolling when cramped', () => {
+    const css = fs.readFileSync(path.join(root, 'css', 'style.css'), 'utf-8');
+    const navMatch = css.match(/\.ops-nav\s*{[\s\S]*?}/);
+    assert.ok(navMatch, '.ops-nav rules for mobile not found');
+    const navBlock = navMatch[0];
+    assert.ok(navBlock.includes('overflow-x: auto'), '.ops-nav should allow horizontal scrolling');
+  });
+
+  test('menu toggle not forcibly hidden on wide screens', () => {
+    const css = fs.readFileSync(path.join(root, 'css', 'style.css'), 'utf-8');
+    assert.ok(!/\.nav-menu-toggle\s*{[^}]*display:\s*none/.test(css), 'nav menu toggle should remain visible');
+  });
 
 // Verify HTML structure defaults (nav links closed)
 const pages = ['index.html', 'contact-center.html', 'it-support.html', 'professional-services.html'];

--- a/tests/ui/nav_and_fab_layout.test.js
+++ b/tests/ui/nav_and_fab_layout.test.js
@@ -26,7 +26,7 @@ test('fab stack uses safe-area margins and button sizes', () => {
 });
 
 test('fab stack renders buttons in order', () => {
-  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { runScripts: 'dangerously', url: 'http://localhost' });
+  const dom = new JSDOM('<!DOCTYPE html><html><body><button class="nav-menu-toggle"></button></body></html>', { runScripts: 'dangerously', url: 'http://localhost' });
   const { window } = dom;
   Object.defineProperty(window, 'innerWidth', { value: 500, configurable: true });
   window.fetch = async () => ({ text: async () => '<div></div>' });
@@ -35,6 +35,18 @@ test('fab stack renders buttons in order', () => {
   window.document.dispatchEvent(new window.Event('DOMContentLoaded'));
   const ids = Array.from(window.document.querySelectorAll('.fab')).map(b => b.id);
   assert.deepStrictEqual(ids, ['fab-contact', 'fab-join', 'fab-chatbot', 'fab-menu']);
+});
+
+test('menu fab omitted when nav toggle missing', () => {
+  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { runScripts: 'dangerously', url: 'http://localhost' });
+  const { window } = dom;
+  Object.defineProperty(window, 'innerWidth', { value: 500, configurable: true });
+  window.fetch = async () => ({ text: async () => '<div></div>' });
+  const code = fs.readFileSync(path.join(root, 'cojoinlistener.js'), 'utf-8');
+  window.eval(code);
+  window.document.dispatchEvent(new window.Event('DOMContentLoaded'));
+  const ids = Array.from(window.document.querySelectorAll('.fab')).map(b => b.id);
+  assert.deepStrictEqual(ids, ['fab-contact', 'fab-join', 'fab-chatbot']);
 });
 
 test('nav toggles remain visible without shrinking', () => {


### PR DESCRIPTION
## Summary
- Only add menu FAB when `.nav-menu-toggle` is present
- Keep nav menu toggle visible on wide screens
- Update navigation tests to cover new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896fce2de98832bb80897dd8ad73c96