### PR TITLE
Refactor chatbot header layout

### DIFF
--- a/fabs/chatbot.html
+++ b/fabs/chatbot.html
@@ -1,10 +1,14 @@
 <!-- This is a fragment, intended to be loaded dynamically -->
 <div id="modal-chatbot" role="dialog" aria-modal="true" aria-labelledby="title">
   <div id="chatbot-header">
-    <span id="title" data-en="Chattia" data-es="Chattia">Chattia</span>
+    <div class="chatbot-header-top">
+      <span id="title" data-en="Chattia" data-es="Chattia">Chattia</span>
+      <button id="chatbot-close" type="button" class="modal-close" aria-label="Close">
+        <i class="fas fa-times"></i>
+      </button>
+    </div>
 
-    <!-- tiny controls -->
-    <div>
+    <div id="chatbot-controls">
       <span id="langCtrl" class="ctrl">ES</span>
       &nbsp;|&nbsp;
       <span id="themeCtrl" class="ctrl">Dark</span>
@@ -19,9 +23,6 @@
              data-en-ph="Type your message..." data-es-ph="Escriba su mensaje...">
       <button id="chatbot-send" type="submit" disabled aria-label="Send">
         <i class="fas fa-arrow-right"></i>
-      </button>
-      <button id="chatbot-close" type="button" class="modal-close" aria-label="Close">
-        <i class="fas fa-times"></i>
       </button>
       <button id="chatbot-close-text" type="button" class="modal-close">Close</button>
     </form>

--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -37,9 +37,9 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
 }
 #chatbot-header{
   display:flex;
-  justify-content:space-between;
-  align-items:center;
-  gap:.5rem;
+  flex-direction:column;
+  align-items:flex-end;
+  gap:.25rem;
   background:linear-gradient(135deg,var(--clr-primary) 0%,var(--clr-accent) 100%);
   color:#fff;
   font-weight:600;
@@ -51,6 +51,19 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
   z-index: 1;
 }
 #chatbot-header #title{color:#000;}
+
+.chatbot-header-top{
+  width:100%;
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+}
+
+#chatbot-controls{
+  display:flex;
+  align-items:center;
+  font-size:.75rem;
+}
 @media (max-width: 47.9375rem) {
   #modal-chatbot {
     width: 100vw;
@@ -129,7 +142,6 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
 }
 #chatbot-send:hover i{transform:rotate(-45deg)}
 #chatbot-send:disabled{background:#555;cursor:not-allowed}
-#chatbot-close{margin-left:0}
 .human-check{color:#ddd;font-size:.85rem;display:flex;align-items:center;margin-top:.3rem}
 .human-check input{margin-right:.4rem}
 

--- a/fabs/js/chattia.js
+++ b/fabs/js/chattia.js
@@ -12,6 +12,15 @@ function initChatbot() {
   const chatbotContainer = qs('#modal-chatbot');
   if (!chatbotContainer) return;
 
+  const closeBtn = qs('#chatbot-close');
+  if (closeBtn) {
+    closeBtn.addEventListener('click', () => {
+      if (window.hideActiveFabModal) {
+        window.hideActiveFabModal();
+      }
+    });
+  }
+
   /* === Language toggle === */
   const langCtrl = qs('#langCtrl'),
         transNodes = qsa('[data-en]'),
@@ -57,7 +66,7 @@ function initChatbot() {
 
   // Focus the input field when the chatbot initializes so keyboard users
   // can immediately begin typing. The close button remains reachable via
-  // Tab navigation within the form.
+  // Tab navigation within the header.
   if (input && input.focus) {
     input.focus();
   }

--- a/tests/chatbot-modal.test.js
+++ b/tests/chatbot-modal.test.js
@@ -151,14 +151,26 @@ function createChatbotModal() {
 
   const header = new Element('div');
   header.id = 'chatbot-header';
+
+  const top = new Element('div');
+  top.className = 'chatbot-header-top';
   const title = new Element('span');
   title.id = 'title';
   title.dataset.en = 'OPS AI Chatbot';
   title.dataset.es = 'Chatbot OPS AI';
   title.textContent = 'OPS AI Chatbot';
-  header.appendChild(title);
+  top.appendChild(title);
+
+  const closeBtn = new Element('button');
+  closeBtn.id = 'chatbot-close';
+  closeBtn.className = 'modal-close';
+  closeBtn.setAttribute('aria-label', 'Close');
+  closeBtn.textContent = 'Close';
+  top.appendChild(closeBtn);
+  header.appendChild(top);
 
   const controls = new Element('div');
+  controls.id = 'chatbot-controls';
   const langCtrl = new Element('span');
   langCtrl.id = 'langCtrl';
   langCtrl.className = 'ctrl';
@@ -192,13 +204,6 @@ function createChatbotModal() {
   send.id = 'chatbot-send';
   send.disabled = true;
   form.appendChild(send);
-
-  const closeBtn = new Element('button');
-  closeBtn.id = 'chatbot-close';
-  closeBtn.className = 'modal-close';
-  closeBtn.setAttribute('aria-label', 'Close');
-  closeBtn.textContent = 'Close';
-  form.appendChild(closeBtn);
   formContainer.appendChild(form);
 
   const label = new Element('label');


### PR DESCRIPTION
## Summary
- Move chatbot close button into header and group language/theme controls beneath it
- Convert chatbot header to column flex layout and position close button top-right
- Bind close button click handler in chattia.js and update tests for new structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896fce65c40832ba9a7d58a03a7fc27