### PR TITLE
Hide desktop hamburger menu

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -745,6 +745,9 @@ body.dark .ops-modal {
     top: 1.2rem;
     right: 2rem;
   }
+  .nav-menu-toggle {
+    display: none;
+  }
 }
 
 @media (min-width: 1024px) {

--- a/tests/mobile-nav.test.js
+++ b/tests/mobile-nav.test.js
@@ -29,9 +29,10 @@ test('mobile nav links use off-canvas layout', () => {
     assert.ok(navBlock.includes('overflow-x: auto'), '.ops-nav should allow horizontal scrolling');
   });
 
-  test('menu toggle not forcibly hidden on wide screens', () => {
+  test('menu toggle hidden on wide screens', () => {
     const css = fs.readFileSync(path.join(root, 'css', 'style.css'), 'utf-8');
-    assert.ok(!/\.nav-menu-toggle\s*{[^}]*display:\s*none/.test(css), 'nav menu toggle should remain visible');
+    const pattern = /@media\s*\(min-width:\s*1025px\)[\s\S]*?\.nav-menu-toggle\s*{[^}]*display:\s*none/;
+    assert.ok(pattern.test(css), 'nav menu toggle should be hidden on wide screens');
   });
 
 // Verify HTML structure defaults (nav links closed)


### PR DESCRIPTION
## Summary
- Hide header hamburger on screens wider than 1024px to eliminate duplicate navigation
- Update navigation test to verify hamburger is removed on large displays

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897077d18e0832b9f8d64560c51a882