### PR TITLE
feat: toggle menu FAB based on screen width

### DIFF
--- a/cojoinlistener.js
+++ b/cojoinlistener.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const body = document.body;
 
   let fabStack = null;
+  let menuFab = null;
   let activeModal = null;
   let overlay = null;
   let lastFocused = null; // Remember focus to restore when modal closes
@@ -29,6 +30,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
+  const mobileQuery = '(max-width: 1024px)';
+  function isMobileWidth() {
+    return window.matchMedia(mobileQuery).matches;
+  }
+
   function buildFabStack() {
     if (fabStack) return;
 
@@ -39,29 +45,34 @@ document.addEventListener('DOMContentLoaded', () => {
     const contactFab = createFab('contact', '<i class="fa fa-envelope"></i>', 'Contact Us', 'fab--contact');
     const joinFab = createFab('join', '<i class="fa fa-user-plus"></i>', 'Join Us', 'fab--join');
     const chatbotFab = createFab('chatbot', '<i class="fa fa-comments"></i>', 'Chatbot', 'fab--chatbot');
-    const navToggle = document.querySelector('.nav-menu-toggle');
-    let menuFab;
-    if (navToggle) {
-      menuFab = createFab('menu', '<i class="fa fa-bars"></i>', 'Menu', 'fab--menu');
-    }
 
     fabStack.appendChild(contactFab);
     fabStack.appendChild(joinFab);
     fabStack.appendChild(chatbotFab);
-    if (menuFab) {
-      fabStack.appendChild(menuFab);
-    }
 
     contactFab.addEventListener('click', () => showModal('contact'));
     joinFab.addEventListener('click', () => showModal('join'));
     chatbotFab.addEventListener('click', () => showModal('chatbot'));
-    if (menuFab) {
+  }
+
+  function updateMenuFab() {
+    const navToggle = document.querySelector('.nav-menu-toggle');
+    const shouldShow = navToggle && isMobileWidth();
+    if (shouldShow && !menuFab) {
+      menuFab = createFab('menu', '<i class="fa fa-bars"></i>', 'Menu', 'fab--menu');
       menuFab.addEventListener('click', () => {
         const navToggle = document.querySelector('.nav-menu-toggle');
         if (navToggle && navToggle.click) {
           navToggle.click();
         }
       });
+      fabStack.appendChild(menuFab);
+    } else if (!shouldShow && menuFab) {
+      menuFab.remove();
+      menuFab = null;
+      if (navToggle && navToggle.getAttribute('aria-expanded') === 'true' && navToggle.click) {
+        navToggle.click();
+      }
     }
   }
 
@@ -69,10 +80,10 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!fabStack) {
       buildFabStack();
     }
+    updateMenuFab();
   }
 
   checkFabVisibility();
-  window.addEventListener('resize', checkFabVisibility);
 
   /**
    * Create a single FAB button.
@@ -223,8 +234,9 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  // Adjust draggable on resize
+  // Adjust draggable on resize and toggle menu FAB
   window.addEventListener('resize', () => {
+    checkFabVisibility();
     if (activeModal && window.initDraggableModal) {
       window.initDraggableModal(activeModal);
     }

--- a/cojoinlistener.js
+++ b/cojoinlistener.js
@@ -31,8 +31,9 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   const mobileQuery = '(max-width: 1024px)';
+  const mobileMql = window.matchMedia(mobileQuery);
   function isMobileWidth() {
-    return window.matchMedia(mobileQuery).matches;
+    return mobileMql.matches;
   }
 
   function buildFabStack() {
@@ -84,6 +85,19 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   checkFabVisibility();
+
+  const handleMediaChange = () => {
+    updateMenuFab();
+    if (activeModal && window.initDraggableModal) {
+      window.initDraggableModal(activeModal);
+    }
+  };
+
+  if (mobileMql.addEventListener) {
+    mobileMql.addEventListener('change', handleMediaChange);
+  } else if (mobileMql.addListener) {
+    mobileMql.addListener(handleMediaChange);
+  }
 
   /**
    * Create a single FAB button.

--- a/fabs/css/cojoin.css
+++ b/fabs/css/cojoin.css
@@ -64,6 +64,12 @@ body {
 .fab--chatbot { background: var(--clr-accent-dark); }
 .fab--menu { background: var(--clr-primary); }
 
+@media (min-width: 1025px) {
+  .fab--menu {
+    display: none;
+  }
+}
+
 @media (max-width: 480px) {
   .fab {
     width: 48px;

--- a/tests/chatbot-modal.test.js
+++ b/tests/chatbot-modal.test.js
@@ -237,6 +237,7 @@ test('chatbot modal initializes and handlers work', async () => {
   window.innerWidth = 500;
   window.addEventListener = () => {};
   window.dispatchEvent = () => {};
+  window.matchMedia = () => ({ matches: window.innerWidth <= 1024, addEventListener: () => {}, removeEventListener: () => {} });
   const context = vm.createContext({ window, document, console, setTimeout, fetch: null });
   context.window.initDraggableModal = () => {};
 
@@ -325,6 +326,7 @@ test('chatbot not initialized when HTML missing', async () => {
   window.innerWidth = 500;
   window.addEventListener = () => {};
   window.dispatchEvent = () => {};
+  window.matchMedia = () => ({ matches: window.innerWidth <= 1024, addEventListener: () => {}, removeEventListener: () => {} });
   const context = vm.createContext({ window, document, console, fetch: null, setTimeout });
   context.window.initDraggableModal = () => {};
 
@@ -350,6 +352,7 @@ test('chatbot FAB click is idempotent', async () => {
   window.innerWidth = 500;
   window.addEventListener = () => {};
   window.dispatchEvent = () => {};
+  window.matchMedia = () => ({ matches: window.innerWidth <= 1024, addEventListener: () => {}, removeEventListener: () => {} });
   const context = vm.createContext({ window, document, console, fetch: null, setTimeout });
   context.window.initDraggableModal = () => {};
 

--- a/tests/nav_and_fab_layout.test.js
+++ b/tests/nav_and_fab_layout.test.js
@@ -6,6 +6,15 @@ const { JSDOM } = require('jsdom');
 
 const root = path.resolve(__dirname, '..');
 
+function mockMatchMedia(win) {
+  win.matchMedia = query => ({
+    matches: win.innerWidth <= 1024,
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {}
+  });
+}
+
 // Ensure FAB container positioning
 test('fab stack uses safe-area margins and button sizes', () => {
   const css = fs.readFileSync(path.join(root, 'fabs', 'css', 'cojoin.css'), 'utf-8');
@@ -29,6 +38,7 @@ test('fab stack renders buttons in order', () => {
   const dom = new JSDOM('<!DOCTYPE html><html><body><button class="nav-menu-toggle"></button></body></html>', { runScripts: 'dangerously', url: 'http://localhost' });
   const { window } = dom;
   Object.defineProperty(window, 'innerWidth', { value: 500, configurable: true });
+  mockMatchMedia(window);
   window.fetch = async () => ({ text: async () => '<div></div>' });
   const code = fs.readFileSync(path.join(root, 'cojoinlistener.js'), 'utf-8');
   window.eval(code);
@@ -41,12 +51,29 @@ test('menu fab omitted when nav toggle missing', () => {
   const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { runScripts: 'dangerously', url: 'http://localhost' });
   const { window } = dom;
   Object.defineProperty(window, 'innerWidth', { value: 500, configurable: true });
+  mockMatchMedia(window);
   window.fetch = async () => ({ text: async () => '<div></div>' });
   const code = fs.readFileSync(path.join(root, 'cojoinlistener.js'), 'utf-8');
   window.eval(code);
   window.document.dispatchEvent(new window.Event('DOMContentLoaded'));
   const ids = Array.from(window.document.querySelectorAll('.fab')).map(b => b.id);
   assert.deepStrictEqual(ids, ['fab-contact', 'fab-join', 'fab-chatbot']);
+});
+
+test('menu fab toggles around 1024px width', () => {
+  const dom = new JSDOM('<!DOCTYPE html><html><body><button class="nav-menu-toggle" aria-expanded="false"></button><div class="nav-links"></div></body></html>', { runScripts: 'dangerously', url: 'http://localhost' });
+  const { window } = dom;
+  Object.defineProperty(window, 'innerWidth', { value: 1024, configurable: true });
+  mockMatchMedia(window);
+  window.fetch = async () => ({ text: async () => '<div></div>' });
+  const code = fs.readFileSync(path.join(root, 'cojoinlistener.js'), 'utf-8');
+  window.eval(code);
+  window.document.dispatchEvent(new window.Event('DOMContentLoaded'));
+  assert.ok(window.document.getElementById('fab-menu'), 'menu fab should show at 1024px');
+
+  Object.defineProperty(window, 'innerWidth', { value: 1025, configurable: true });
+  window.dispatchEvent(new window.Event('resize'));
+  assert.ok(!window.document.getElementById('fab-menu'), 'menu fab should hide above 1024px');
 });
 
 test('nav toggles remain visible without shrinking', () => {


### PR DESCRIPTION
## Summary
- only render the navigation menu FAB when the screen width is 1024px or smaller
- hide menu FAB via CSS for large viewports
- add tests for menu FAB visibility across breakpoints

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897812cd938832bb3e76937687f9047