### PR TITLE
Ensure modals fill viewport on short screens

### DIFF
--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -83,19 +83,19 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
     height: calc(var(--vh, 1vh) * 90);
   }
 }
-@media (max-height:35rem){
+@media (max-height: 560px){
   #modal-chatbot{
-    width:100vw;
-    height: calc(var(--vh, 1vh) * 100);
-    border-radius:0;
-    top:0;
-    left:0;
-    transform:none;
-    overflow-y:auto;
-    max-width:none;
-    max-height:none;
+    width: 100vw;
+    height: 100dvh;
+    border-radius: 0;
+    top: 0;
+    left: 0;
+    transform: none;
+    overflow-y: auto;
+    max-width: none;
+    max-height: none;
   }
-  #chatbot-header{cursor:default;}
+  #chatbot-header{cursor: default;}
 }
 #chatbot-header .ctrl{cursor:pointer;font-size:.75rem;font-weight:500;user-select:none;opacity:.85}
 #chatbot-header .ctrl:hover{opacity:1}

--- a/fabs/css/cojoin.css
+++ b/fabs/css/cojoin.css
@@ -143,7 +143,7 @@ body[data-lock="true"] {
 @media (max-height: 560px) {
   .modal-container {
     width: 100vw;
-    height: calc(var(--vh, 1vh) * 100);
+    height: 100dvh;
   }
 }
 

--- a/tests/nav_and_fab_layout.test.js
+++ b/tests/nav_and_fab_layout.test.js
@@ -25,9 +25,16 @@ test('fab stack uses safe-area margins and button sizes', () => {
 });
 
 test('fab stack renders buttons in order', () => {
-  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { runScripts: 'dangerously', url: 'http://localhost' });
+  const dom = new JSDOM('<!DOCTYPE html><html><body><button class="nav-menu-toggle"></button></body></html>', { runScripts: 'dangerously', url: 'http://localhost' });
   const { window } = dom;
   Object.defineProperty(window, 'innerWidth', { value: 500, configurable: true });
+  window.matchMedia = window.matchMedia || (() => ({
+    matches: window.innerWidth <= 1024,
+    addEventListener: () => {},
+    addListener: () => {},
+    removeEventListener: () => {},
+    removeListener: () => {}
+  }));
   window.fetch = async () => ({ text: async () => '<div></div>' });
   const code = fs.readFileSync(path.join(root, 'cojoinlistener.js'), 'utf-8');
   window.eval(code);

--- a/tests/viewport.test.js
+++ b/tests/viewport.test.js
@@ -35,10 +35,10 @@ test('page and modal styles rely on --vh variable', () => {
 
   const chatbotCss = fs.readFileSync(path.join(root, 'fabs', 'css', 'chatbot.css'), 'utf8');
   assert.ok(/height:\s*calc\(var\(--vh, 1vh\) \* 90\)/.test(chatbotCss), 'chatbot modal should use --vh');
-  assert.ok(/height:\s*calc\(var\(--vh, 1vh\) \* 100\)/.test(chatbotCss), 'chatbot modal should expand using --vh on mobile');
+  assert.ok(/height:\s*100dvh/.test(chatbotCss), 'chatbot modal should expand to full viewport height on mobile');
   assert.ok(/#modal-chatbot\.is-visible\s*{[\s\S]*display\s*:\s*flex/.test(chatbotCss), 'chatbot modal should display when visible');
 
   const cojoinCss = fs.readFileSync(path.join(root, 'fabs', 'css', 'cojoin.css'), 'utf8');
   assert.ok(/height:\s*calc\(var\(--vh, 1vh\) \* 90\)/.test(cojoinCss), 'cojoin modal should use --vh');
-  assert.ok(/height:\s*calc\(var\(--vh, 1vh\) \* 100\)/.test(cojoinCss), 'cojoin modal should expand using --vh on mobile');
+  assert.ok(/height:\s*100dvh/.test(cojoinCss), 'cojoin modal should expand to full viewport height on mobile');
 });


### PR DESCRIPTION
## Summary
- use 100dvh and 100vw for modals when viewport height is 560px or less
- keep modal headers and footers sticky while hiding overflow
- update tests for dvh-based sizing and fab stack setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68979e7539e0832b9e6dde1027438ca0