### PR TITLE
Adjust responsive navigation height

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -169,10 +169,11 @@ li {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  height: 64px;
-  padding: 0 2rem;
-  padding-left: calc(2rem + env(safe-area-inset-left));
-  padding-right: calc(2rem + env(safe-area-inset-right));
+  height: 56px;
+  line-height: 56px;
+  padding: 0 1rem;
+  padding-left: calc(1rem + env(safe-area-inset-left));
+  padding-right: calc(1rem + env(safe-area-inset-right));
   font-weight: 600;
   overflow-x: auto;
 }
@@ -689,6 +690,13 @@ body.dark .ops-modal {
 }
 
 @media (min-width: 768px) {
+  .ops-nav {
+    height: 64px;
+    line-height: 64px;
+    padding: 0 2rem;
+    padding-left: calc(2rem + env(safe-area-inset-left));
+    padding-right: calc(2rem + env(safe-area-inset-right));
+  }
   h1 {
     font-size: 2.8rem;
   }

--- a/tests/nav_and_fab_layout.test.js
+++ b/tests/nav_and_fab_layout.test.js
@@ -25,9 +25,12 @@ test('fab stack uses safe-area margins and button sizes', () => {
 });
 
 test('fab stack renders buttons in order', () => {
-  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { runScripts: 'dangerously', url: 'http://localhost' });
+  const dom = new JSDOM('<!DOCTYPE html><html><body><button class="nav-menu-toggle"></button></body></html>', { runScripts: 'dangerously', url: 'http://localhost' });
   const { window } = dom;
   Object.defineProperty(window, 'innerWidth', { value: 500, configurable: true });
+  window.matchMedia = window.matchMedia || function() {
+    return { matches: true, addListener() {}, removeListener() {} };
+  };
   window.fetch = async () => ({ text: async () => '<div></div>' });
   const code = fs.readFileSync(path.join(root, 'cojoinlistener.js'), 'utf-8');
   window.eval(code);


### PR DESCRIPTION
## Summary
- Ensure the top navigation bar uses 56px height on small screens and 64px on wider viewports, with matching line-height and safe-area padding
- Add matchMedia polyfill and nav-menu-toggle stub in tests to validate FAB order reliably

## Testing
- `npm test`
- `npm run ci:test`


------
https://chatgpt.com/codex/tasks/task_e_68979e78b6c0832bb825e185ce64c019