### PR TITLE
Constrain modal transitions and honor reduced motion

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -541,7 +541,7 @@ body.dark .card .icon > i {
   border: 0.0625rem solid rgba(0, 0, 0, 0.1);
   box-shadow: 0 0.25rem 1.25rem rgba(0, 0, 0, 0.15);
   padding: 2.1rem 2.2rem 1.3rem 2.2rem;
-  transition: box-shadow 0.25s;
+  transition: box-shadow 0.25s, transform 0.25s ease, opacity 0.25s ease;
   cursor: default;
   z-index: 3000;
   display: flex;
@@ -769,6 +769,9 @@ body.dark .ops-modal {
   }
   body {
     animation: none !important;
+  }
+  .ops-modal {
+    transition: none !important;
   }
 }
 

--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -30,6 +30,7 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
   transform: translate(-50%, -50%);
   z-index: 1001;
   display: none;
+  transition: transform 0.25s ease, opacity 0.25s ease;
 }
 
 #modal-chatbot.is-visible {
@@ -146,6 +147,9 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
 .human-check input{margin-right:.4rem}
 
 @media (prefers-reduced-motion: reduce) {
+  #modal-chatbot {
+    transition: none !important;
+  }
   *, *::before, *::after {
     animation: none !important;
     transition: none !important;

--- a/fabs/css/cojoin.css
+++ b/fabs/css/cojoin.css
@@ -117,7 +117,7 @@ body[data-lock="true"] {
   flex-direction: column;
   z-index: 1001;
   overflow: hidden;
-  transition: transform 0.3s ease;
+  transition: transform 0.25s ease;
 }
 
 .modal-container.is-visible {
@@ -328,6 +328,9 @@ button.submit-btn:hover {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .modal-container {
+    transition: none !important;
+  }
   *, *::before, *::after {
     animation: none !important;
     transition: none !important;


### PR DESCRIPTION
## Summary
- Limit modal transform and opacity transitions to ~250ms
- Disable modal animations when `prefers-reduced-motion` is set

## Testing
- `npm test` *(fails: nav FAB layout mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68979e7cca6c832b8c39398b55cf09bc