### PR TITLE
feat: improve chatbot modal responsiveness

### DIFF
--- a/fabs/chatbot.html
+++ b/fabs/chatbot.html
@@ -1,5 +1,5 @@
 <!-- This is a fragment, intended to be loaded dynamically -->
-<div id="modal-chatbot" role="dialog" aria-modal="true" aria-labelledby="title">
+<div id="modal-chatbot" class="modal-container" role="dialog" aria-modal="true" aria-labelledby="title">
   <div id="chatbot-header">
     <div class="chatbot-header-top">
       <span id="title" data-en="Chattia" data-es="Chattia">Chattia</span>

--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -11,30 +11,34 @@
 }
 body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
 
-/* ---------- CHATBOT ---------- */
-#modal-chatbot{
-  width: 90vw;
-  max-width: 400px;
-  height: calc(var(--vh, 1vh) * 90);
-  max-height: 600px;
-  background:#251541;
-  border:0.125rem solid var(--clr-accent);
-  border-radius:1.125rem;
-  box-shadow:0 0.5rem 2rem #0006;
-  display:flex;
-  flex-direction:column;
-  overflow:hidden;
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  z-index: 1001;
-  display: none;
+/* Lock body scrolling when a modal is open */
+html[data-lock="true"],
+body[data-lock="true"] {
+  overflow: hidden;
 }
 
+/* ---------- CHATBOT ---------- */
+#modal-chatbot{
+    width: 85vw;
+    height: 85dvh;
+    background:#251541;
+    border:0.125rem solid var(--clr-accent);
+    border-radius:1.125rem;
+    box-shadow:0 0.5rem 2rem #0006;
+    display:flex;
+    flex-direction:column;
+    overflow:hidden;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 1001;
+    display: none;
+  }
+
 #modal-chatbot.is-visible {
-  display: flex;
-}
+    display: flex;
+  }
 #chatbot-header{
   display:flex;
   flex-direction:column;
@@ -64,38 +68,24 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
   align-items:center;
   font-size:.75rem;
 }
-@media (max-width: 47.9375rem) {
+@media (min-width: 768px) {
   #modal-chatbot {
-    width: 100vw;
-    height: calc(var(--vh, 1vh) * 100);
-    border-radius: 0;
-    top: 0;
-    left: 0;
-    transform: none;
-    overflow-y: auto;
-    max-width: none;
-    max-height: none;
-  }
+      width: clamp(70vw, 75vw, 75vw);
+      height: clamp(75dvh, 80dvh, 85dvh);
+    }
 }
-@media (max-width:47.9375rem){
+
+@media (max-height: 560px) {
   #modal-chatbot{
-    width:85vw;
-    height: calc(var(--vh, 1vh) * 90);
-  }
-}
-@media (max-height:35rem){
-  #modal-chatbot{
-    width:100vw;
-    height: calc(var(--vh, 1vh) * 100);
-    border-radius:0;
-    top:0;
-    left:0;
-    transform:none;
-    overflow-y:auto;
-    max-width:none;
-    max-height:none;
-  }
-  #chatbot-header{cursor:default;}
+      width:100vw;
+      height:100dvh;
+      border-radius:0;
+      top:0;
+      left:0;
+      transform:none;
+      overflow-y:auto;
+    }
+    #chatbot-header{cursor:default;}
 }
 #chatbot-header .ctrl{cursor:pointer;font-size:.75rem;font-weight:500;user-select:none;opacity:.85}
 #chatbot-header .ctrl:hover{opacity:1}

--- a/tests/nav_and_fab_layout.test.js
+++ b/tests/nav_and_fab_layout.test.js
@@ -25,9 +25,18 @@ test('fab stack uses safe-area margins and button sizes', () => {
 });
 
 test('fab stack renders buttons in order', () => {
-  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { runScripts: 'dangerously', url: 'http://localhost' });
-  const { window } = dom;
-  Object.defineProperty(window, 'innerWidth', { value: 500, configurable: true });
+    const dom = new JSDOM('<!DOCTYPE html><html><body><button class="nav-menu-toggle"></button></body></html>', { runScripts: 'dangerously', url: 'http://localhost' });
+    const { window } = dom;
+    window.matchMedia = window.matchMedia || function () {
+      return {
+        matches: true,
+        addListener() {},
+        removeListener() {},
+        addEventListener() {},
+        removeEventListener() {}
+      };
+    };
+    Object.defineProperty(window, 'innerWidth', { value: 500, configurable: true });
   window.fetch = async () => ({ text: async () => '<div></div>' });
   const code = fs.readFileSync(path.join(root, 'cojoinlistener.js'), 'utf-8');
   window.eval(code);

--- a/tests/viewport.test.js
+++ b/tests/viewport.test.js
@@ -33,10 +33,10 @@ test('page and modal styles rely on --vh variable', () => {
   assert.ok(modalMatch, 'ops-modal styles not found');
   assert.ok(/max-height:\s*calc\(var\(--vh, 1vh\) \* 80\)/.test(modalMatch[0]), 'ops-modal should use --vh for max-height');
 
-  const chatbotCss = fs.readFileSync(path.join(root, 'fabs', 'css', 'chatbot.css'), 'utf8');
-  assert.ok(/height:\s*calc\(var\(--vh, 1vh\) \* 90\)/.test(chatbotCss), 'chatbot modal should use --vh');
-  assert.ok(/height:\s*calc\(var\(--vh, 1vh\) \* 100\)/.test(chatbotCss), 'chatbot modal should expand using --vh on mobile');
-  assert.ok(/#modal-chatbot\.is-visible\s*{[\s\S]*display\s*:\s*flex/.test(chatbotCss), 'chatbot modal should display when visible');
+    const chatbotCss = fs.readFileSync(path.join(root, 'fabs', 'css', 'chatbot.css'), 'utf8');
+    assert.ok(/height:\s*85dvh/.test(chatbotCss), 'chatbot modal should use dvh');
+    assert.ok(/height:\s*100dvh/.test(chatbotCss), 'chatbot modal should expand using dvh on small viewports');
+    assert.ok(/#modal-chatbot\.is-visible\s*{[\s\S]*display\s*:\s*flex/.test(chatbotCss), 'chatbot modal should display when visible');
 
   const cojoinCss = fs.readFileSync(path.join(root, 'fabs', 'css', 'cojoin.css'), 'utf8');
   assert.ok(/height:\s*calc\(var\(--vh, 1vh\) \* 90\)/.test(cojoinCss), 'cojoin modal should use --vh');


### PR DESCRIPTION
## Summary
- refine chatbot modal markup with `modal-container` wrapper
- apply responsive dvh-based sizing and scroll locking styles
- align viewport and FAB tests with new responsiveness

## Testing
- `npm test`
- `npm run ci:test`


------
https://chatgpt.com/codex/tasks/task_e_68979e7188ac832bbe866ad80e0cd632