### PR TITLE
feat: add data-lang support and form error hooks

### DIFF
--- a/contact-center.html
+++ b/contact-center.html
@@ -59,19 +59,19 @@
     </section>
 
     <section id="form" class="contact-form-section">
-        <h2 data-key="assessment-heading"></h2>
+        <h2 data-en="Request Your Free Needs Assessment" data-es="Solicite su Evaluación de Necesidades Gratis">Request Your Free Needs Assessment</h2>
       <form>
         <div class="form-errors" aria-live="polite"></div>
-        <input type="text" placeholder="" data-key="form-name" required />
-        <input type="email" placeholder="" data-key="form-email" required />
-        <input type="tel" placeholder="" data-key="form-phone" required />
-        <input type="text" placeholder="" data-key="form-company" required />
+        <input type="text" required placeholder="Full Name" data-en-placeholder="Full Name" data-es-placeholder="Nombre Completo" />
+        <input type="email" required placeholder="Business Email" data-en-placeholder="Business Email" data-es-placeholder="Correo Electrónico Empresarial" />
+        <input type="tel" required placeholder="Your Phone Number" data-en-placeholder="Your Phone Number" data-es-placeholder="Su Número de Teléfono" />
+        <input type="text" required placeholder="Company" data-en-placeholder="Company" data-es-placeholder="Empresa" />
         <div class="h-captcha" data-sitekey="your_site_key"></div>
         <div class="honeypot" aria-hidden="true">
-          <label for="hp-field">Leave this field blank</label>
+          <label for="hp-field" data-en="Leave this field blank" data-es="Deje este campo en blanco">Leave this field blank</label>
           <input type="text" id="hp-field" name="hp" tabindex="-1" autocomplete="off" />
         </div>
-          <button type="submit" class="submit-button" data-key="form-submit"></button>
+          <button type="submit" class="submit-button" data-en="Request Now" data-es="Solicitar Ahora">Request Now</button>
       </form>
     </section>
   </main>

--- a/fabs/contact.html
+++ b/fabs/contact.html
@@ -1,7 +1,7 @@
 <!-- This is a fragment, intended to be loaded dynamically -->
-<div id="modal-contact-center" class="modal-container" role="dialog" aria-modal="true">
+<div id="modal-contact-center" class="modal-container" role="dialog" aria-modal="true" data-lang="en">
   <div class="modal__header">
-    <h1>Contact Us</h1>
+    <h1 data-en="Contact Us" data-es="Contáctanos">Contact Us</h1>
     <button class="modal-close"><i class="fas fa-times"></i></button>
   </div>
   <div class="modal-content">
@@ -9,56 +9,56 @@
       <div class="form-errors" aria-live="polite"></div>
       <div class="form-row">
         <div class="form-cell">
-          <label for="name">Name</label>
-          <input id="name" name="name" required placeholder="Enter your name" />
+          <label for="name" data-en="Name" data-es="Nombre">Name</label>
+          <input id="name" name="name" required placeholder="Enter your name" data-en-placeholder="Enter your name" data-es-placeholder="Ingrese su nombre" />
         </div>
         <div class="form-cell">
-          <label for="email">Email</label>
-          <input id="email" name="email" type="email" required placeholder="Enter your email" />
+          <label for="email" data-en="Email" data-es="Correo electrónico">Email</label>
+          <input id="email" name="email" type="email" required placeholder="Enter your email" data-en-placeholder="Enter your email" data-es-placeholder="Ingrese su correo electrónico" />
         </div>
       </div>
 
       <div class="form-row">
         <div class="form-cell">
-          <label for="contactNumber">Contact Number</label>
-          <input id="contactNumber" name="contactNumber" type="tel" required placeholder="Enter your contact number" />
+          <label for="contactNumber" data-en="Contact Number" data-es="Número de contacto">Contact Number</label>
+          <input id="contactNumber" name="contactNumber" type="tel" required placeholder="Enter your contact number" data-en-placeholder="Enter your contact number" data-es-placeholder="Ingrese su número de contacto" />
         </div>
         <div class="form-cell">
-          <label for="preferredDate">Preferred Date</label>
+          <label for="preferredDate" data-en="Preferred Date" data-es="Fecha preferida">Preferred Date</label>
           <input id="preferredDate" name="preferredDate" type="date" required />
         </div>
       </div>
 
       <div class="form-row">
         <div class="form-cell">
-          <label for="preferredTime">Preferred Time</label>
+          <label for="preferredTime" data-en="Preferred Time" data-es="Hora preferida">Preferred Time</label>
           <input id="preferredTime" name="preferredTime" type="time" required />
         </div>
         <div class="form-cell">
-          <label for="interest">What are you interested about?</label>
+          <label for="interest" data-en="What are you interested about?" data-es="¿En qué está interesado?">What are you interested about?</label>
           <select id="interest" name="interest" required>
-            <option value="" disabled selected>Select an option</option>
-            <option>Business Operations</option>
-            <option>Contact Center</option>
-            <option>IT Support</option>
-            <option>Professionals</option>
+            <option value="" disabled selected data-en="Select an option" data-es="Seleccione una opción">Select an option</option>
+            <option data-en="Business Operations" data-es="Operaciones de Negocio">Business Operations</option>
+            <option data-en="Contact Center" data-es="Centro de Contacto">Contact Center</option>
+            <option data-en="IT Support" data-es="Soporte IT">IT Support</option>
+            <option data-en="Professionals" data-es="Profesionales">Professionals</option>
           </select>
         </div>
       </div>
 
       <div class="mt-1">
-        <label for="comments">Comments</label>
-        <textarea id="comments" name="comments" rows="4" placeholder="What service are you interested in?"></textarea>
+        <label for="comments" data-en="Comments" data-es="Comentarios">Comments</label>
+        <textarea id="comments" name="comments" rows="4" placeholder="What service are you interested in?" data-en-placeholder="What service are you interested in?" data-es-placeholder="¿En qué servicio está interesado?"></textarea>
       </div>
 
       <!-- Honeypot Field for security -->
       <div class="honeypot">
-        <label for="honeypot-contact">Leave this field blank</label>
+        <label for="honeypot-contact" data-en="Leave this field blank" data-es="Deje este campo en blanco">Leave this field blank</label>
         <input type="text" id="honeypot-contact" name="honeypot-contact" />
       </div>
 
       <div class="modal__footer">
-        <button type="submit" class="submit-btn">Send</button>
+        <button type="submit" class="submit-btn" data-en="Send" data-es="Enviar">Send</button>
       </div>
     </form>
   </div>

--- a/fabs/join.html
+++ b/fabs/join.html
@@ -1,7 +1,7 @@
 <!-- This is a fragment, intended to be loaded dynamically -->
-<div id="modal-join-us" class="modal-container" role="dialog" aria-modal="true">
+<div id="modal-join-us" class="modal-container" role="dialog" aria-modal="true" data-lang="en">
   <div class="modal__header">
-    <h1>Join Us</h1>
+    <h1 data-en="Join Us" data-es="Únete a nosotros">Join Us</h1>
     <button class="modal-close"><i class="fas fa-times"></i></button>
   </div>
   <div class="modal-content">
@@ -9,16 +9,16 @@
       <div class="form-errors" aria-live="polite"></div>
       <div class="form-pairs">
         <div>
-          <label for="name">Name</label>
-          <input id="name" name="name" required placeholder="Enter your name" />
+          <label for="name" data-en="Name" data-es="Nombre">Name</label>
+          <input id="name" name="name" required placeholder="Enter your name" data-en-placeholder="Enter your name" data-es-placeholder="Ingrese su nombre" />
         </div>
         <div>
-          <label for="email">Email</label>
-          <input id="email" type="email" name="email" required placeholder="Enter your email" />
+          <label for="email" data-en="Email" data-es="Correo electrónico">Email</label>
+          <input id="email" type="email" name="email" required placeholder="Enter your email" data-en-placeholder="Enter your email" data-es-placeholder="Ingrese su correo electrónico" />
         </div>
         <div>
-          <label for="phone">Phone</label>
-          <input id="phone" type="tel" name="phone" required placeholder="Enter your phone" />
+          <label for="phone" data-en="Phone" data-es="Teléfono">Phone</label>
+          <input id="phone" type="tel" name="phone" required placeholder="Enter your phone" data-en-placeholder="Enter your phone" data-es-placeholder="Ingrese su teléfono" />
         </div>
         <div></div>
       </div>
@@ -26,106 +26,106 @@
       <!-- Dynamic Sections -->
       <div class="form-section" data-section="Skills">
         <div class="section-header">
-          <h2>Skills</h2>
+          <h2 data-en="Skills" data-es="Habilidades">Skills</h2>
           <div>
-            <button type="button" class="circle-btn add" title="Add field">+</button>
-            <button type="button" class="circle-btn remove" title="Remove last field">−</button>
+            <button type="button" class="circle-btn add" title="Add field" data-en-title="Add field" data-es-title="Agregar campo">+</button>
+            <button type="button" class="circle-btn remove" title="Remove last field" data-en-title="Remove last field" data-es-title="Eliminar último campo">−</button>
           </div>
         </div>
         <div class="inputs"></div>
-        <button type="button" class="accept-btn">Accept</button>
-        <button type="button" class="edit-btn hidden">Edit</button>
+        <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
+        <button type="button" class="edit-btn hidden" data-en="Edit" data-es="Editar">Edit</button>
       </div>
 
       <div class="form-section" data-section="Education">
         <div class="section-header">
-          <h2>Education</h2>
+          <h2 data-en="Education" data-es="Educación">Education</h2>
           <div>
-            <button type="button" class="circle-btn add" title="Add field">+</button>
-            <button type="button" class="circle-btn remove" title="Remove last field">−</button>
+            <button type="button" class="circle-btn add" title="Add field" data-en-title="Add field" data-es-title="Agregar campo">+</button>
+            <button type="button" class="circle-btn remove" title="Remove last field" data-en-title="Remove last field" data-es-title="Eliminar último campo">−</button>
           </div>
         </div>
         <div class="inputs"></div>
-        <button type="button" class="accept-btn">Accept</button>
-        <button type="button" class="edit-btn hidden">Edit</button>
+        <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
+        <button type="button" class="edit-btn hidden" data-en="Edit" data-es="Editar">Edit</button>
       </div>
 
       <div class="form-section" data-section="Certification">
         <div class="section-header">
-          <h2>Certification</h2>
+          <h2 data-en="Certification" data-es="Certificación">Certification</h2>
           <div>
-            <button type="button" class="circle-btn add" title="Add field">+</button>
-            <button type="button" class="circle-btn remove" title="Remove last field">−</button>
+            <button type="button" class="circle-btn add" title="Add field" data-en-title="Add field" data-es-title="Agregar campo">+</button>
+            <button type="button" class="circle-btn remove" title="Remove last field" data-en-title="Remove last field" data-es-title="Eliminar último campo">−</button>
           </div>
         </div>
         <div class="inputs"></div>
-        <button type="button" class="accept-btn">Accept</button>
-        <button type="button" class="edit-btn hidden">Edit</button>
+        <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
+        <button type="button" class="edit-btn hidden" data-en="Edit" data-es="Editar">Edit</button>
       </div>
 
       <div class="form-section" data-section="Hobbies">
         <div class="section-header">
-          <h2>Hobbies</h2>
+          <h2 data-en="Hobbies" data-es="Pasatiempos">Hobbies</h2>
           <div>
-            <button type="button" class="circle-btn add" title="Add field">+</button>
-            <button type="button" class="circle-btn remove" title="Remove last field">−</button>
+            <button type="button" class="circle-btn add" title="Add field" data-en-title="Add field" data-es-title="Agregar campo">+</button>
+            <button type="button" class="circle-btn remove" title="Remove last field" data-en-title="Remove last field" data-es-title="Eliminar último campo">−</button>
           </div>
         </div>
         <div class="inputs"></div>
-        <button type="button" class="accept-btn">Accept</button>
-        <button type="button" class="edit-btn hidden">Edit</button>
+        <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
+        <button type="button" class="edit-btn hidden" data-en="Edit" data-es="Editar">Edit</button>
       </div>
 
       <div class="form-section">
-        <h2>What are you interested about?</h2>
+        <h2 data-en="What are you interested about?" data-es="¿En qué está interesado?">What are you interested about?</h2>
         <select id="jn-interest" name="jn-interest" required>
-          <option value="" disabled selected>Select an option</option>
-          <option>Business Operations</option>
-          <option>Contact Center</option>
-          <option>IT Support</option>
-          <option>Professionals</option>
+          <option value="" disabled selected data-en="Select an option" data-es="Seleccione una opción">Select an option</option>
+          <option data-en="Business Operations" data-es="Operaciones de Negocio">Business Operations</option>
+          <option data-en="Contact Center" data-es="Centro de Contacto">Contact Center</option>
+          <option data-en="IT Support" data-es="Soporte IT">IT Support</option>
+          <option data-en="Professionals" data-es="Profesionales">Professionals</option>
         </select>
       </div>
 
       <div class="form-section" data-section="Continued Education">
         <div class="section-header">
-          <h2>Continued Education</h2>
+          <h2 data-en="Continued Education" data-es="Educación Continua">Continued Education</h2>
           <div>
-            <button type="button" class="circle-btn add" title="Add field">+</button>
-            <button type="button" class="circle-btn remove" title="Remove last field">−</button>
+            <button type="button" class="circle-btn add" title="Add field" data-en-title="Add field" data-es-title="Agregar campo">+</button>
+            <button type="button" class="circle-btn remove" title="Remove last field" data-en-title="Remove last field" data-es-title="Eliminar último campo">−</button>
           </div>
         </div>
         <div class="inputs"></div>
-        <button type="button" class="accept-btn">Accept</button>
-        <button type="button" class="edit-btn hidden">Edit</button>
+        <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
+        <button type="button" class="edit-btn hidden" data-en="Edit" data-es="Editar">Edit</button>
       </div>
 
       <div class="form-section" data-section="Experience">
         <div class="section-header">
-          <h2>Experience</h2>
+          <h2 data-en="Experience" data-es="Experiencia">Experience</h2>
           <div>
-            <button type="button" class="circle-btn add" title="Add field">+</button>
-            <button type="button" class="circle-btn remove" title="Remove last field">−</button>
+            <button type="button" class="circle-btn add" title="Add field" data-en-title="Add field" data-es-title="Agregar campo">+</button>
+            <button type="button" class="circle-btn remove" title="Remove last field" data-en-title="Remove last field" data-es-title="Eliminar último campo">−</button>
           </div>
         </div>
         <div class="inputs"></div>
-        <button type="button" class="accept-btn">Accept</button>
-        <button type="button" class="edit-btn hidden">Edit</button>
+        <button type="button" class="accept-btn" data-en="Accept" data-es="Aceptar">Accept</button>
+        <button type="button" class="edit-btn hidden" data-en="Edit" data-es="Editar">Edit</button>
       </div>
 
       <div>
-        <label for="about">Tell us about yourself</label>
-        <textarea id="about" name="about" rows="4" placeholder="Tell us about yourself..."></textarea>
+        <label for="about" data-en="Tell us about yourself" data-es="Cuéntanos sobre ti">Tell us about yourself</label>
+        <textarea id="about" name="about" rows="4" placeholder="Tell us about yourself..." data-en-placeholder="Tell us about yourself..." data-es-placeholder="Cuéntanos sobre ti..."></textarea>
       </div>
 
       <!-- Honeypot Field for security -->
       <div class="honeypot">
-        <label for="honeypot-join">Leave this field blank</label>
+        <label for="honeypot-join" data-en="Leave this field blank" data-es="Deje este campo en blanco">Leave this field blank</label>
         <input type="text" id="honeypot-join" name="honeypot-join" />
       </div>
 
       <div class="modal__footer">
-        <button type="submit" class="submit-btn">Submit</button>
+        <button type="submit" class="submit-btn" data-en="Submit" data-es="Enviar">Submit</button>
       </div>
     </form>
   </div>

--- a/js/langtheme.js
+++ b/js/langtheme.js
@@ -293,6 +293,9 @@ let currentTheme = localStorage.getItem('theme') || 'light';
 
 function updateContent() {
   const elements = document.querySelectorAll('[data-key]');
+  const dataLangElements = document.querySelectorAll('[data-en], [data-es]');
+  const dataPlaceholderElements = document.querySelectorAll('[data-en-placeholder], [data-es-placeholder]');
+  const dataTitleElements = document.querySelectorAll('[data-en-title], [data-es-title]');
   const ariaElements = document.querySelectorAll('[data-aria-label-key]');
   const langButtons = document.querySelectorAll('.lang-toggle');
   const langData = translations[currentLanguage];
@@ -322,6 +325,38 @@ function updateContent() {
       } else {
         el.textContent = translation;
       }
+    }
+  });
+
+  // Elements that store translations directly in data-en/data-es attributes
+  dataLangElements.forEach(el => {
+    const text = el.getAttribute(`data-${currentLanguage}`);
+    if (text !== null) {
+      if (el.tagName === 'IMG' && el.hasAttribute('alt')) {
+        el.alt = text;
+      } else if (el.tagName === 'TITLE') {
+        el.textContent = text;
+      } else if (el.tagName === 'INPUT' && !el.hasAttribute('data-en-placeholder') && !el.hasAttribute('data-es-placeholder')) {
+        el.value = text;
+      } else {
+        el.textContent = text;
+      }
+    }
+  });
+
+  // Update placeholders for inputs/textareas if provided
+  dataPlaceholderElements.forEach(el => {
+    const placeholder = el.getAttribute(`data-${currentLanguage}-placeholder`);
+    if (placeholder !== null) {
+      el.setAttribute('placeholder', placeholder);
+    }
+  });
+
+  // Update title attributes if provided
+  dataTitleElements.forEach(el => {
+    const title = el.getAttribute(`data-${currentLanguage}-title`);
+    if (title !== null) {
+      el.setAttribute('title', title);
     }
   });
 
@@ -375,3 +410,7 @@ document.addEventListener('DOMContentLoaded', () => {
     btn.addEventListener('click', toggleTheme);
   });
 });
+
+// Expose update functions for dynamically loaded content
+window.updateContent = updateContent;
+window.updateTheme = updateTheme;


### PR DESCRIPTION
## Summary
- expose `data-lang` translations through new data attributes
- localize contact, join, and contact center forms
- surface polite form error regions for accessibility

## Testing
- `npm test` *(fails: fab stack renders buttons in order)*

------
https://chatgpt.com/codex/tasks/task_e_68979e7a8174832b958307fdf4d61876