### PR TITLE
Enforce secure cookies

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,9 +5,10 @@ const path = require('path');
 
 const app = express();
 const isProduction = process.env.NODE_ENV === 'production';
+const useSecureCookies = process.env.COOKIE_SECURE !== 'false';
 
-// Enforce HTTPS and secure cookies in production. During local development,
-// set NODE_ENV=development to disable these checks.
+// Enforce HTTPS in production. Cookies are always set to secure unless
+// overridden with COOKIE_SECURE=false for local development.
 if (isProduction) {
   app.use((req, res, next) => {
     if (req.headers['x-forwarded-proto'] !== 'https') {
@@ -29,7 +30,7 @@ app.use(
     cookie: {
       httpOnly: true,
       sameSite: 'strict',
-      secure: isProduction,
+      secure: useSecureCookies,
     },
   })
 );

--- a/tests/nav_and_fab_layout.test.js
+++ b/tests/nav_and_fab_layout.test.js
@@ -25,8 +25,13 @@ test('fab stack uses safe-area margins and button sizes', () => {
 });
 
 test('fab stack renders buttons in order', () => {
-  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { runScripts: 'dangerously', url: 'http://localhost' });
+  const dom = new JSDOM('<!DOCTYPE html><html><body><button class="nav-menu-toggle" aria-expanded="false"></button></body></html>', { runScripts: 'dangerously', url: 'http://localhost' });
   const { window } = dom;
+  window.matchMedia = window.matchMedia || ((q) => ({
+    matches: q.includes('max-width') ? window.innerWidth <= 1024 : false,
+    addListener() {},
+    removeListener() {},
+  }));
   Object.defineProperty(window, 'innerWidth', { value: 500, configurable: true });
   window.fetch = async () => ({ text: async () => '<div></div>' });
   const code = fs.readFileSync(path.join(root, 'cojoinlistener.js'), 'utf-8');


### PR DESCRIPTION
## Summary
- Enforce secure session cookies by default with `COOKIE_SECURE` override for local development
- Stub `matchMedia` and add nav toggle in FAB layout test to ensure test stability

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68979e7e38bc832b9f79361c8bc1de12