### PR TITLE
Use viewport units and safe-area padding

### DIFF
--- a/cojoinlistener.js
+++ b/cojoinlistener.js
@@ -31,7 +31,13 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   const mobileQuery = '(max-width: 1024px)';
-  const mobileMql = window.matchMedia(mobileQuery);
+  const mobileMql = window.matchMedia
+    ? window.matchMedia(mobileQuery)
+    : {
+        matches: window.innerWidth <= 1024,
+        addEventListener: () => {},
+        addListener: () => {},
+      };
   function isMobileWidth() {
     return mobileMql.matches;
   }
@@ -46,34 +52,32 @@ document.addEventListener('DOMContentLoaded', () => {
     const contactFab = createFab('contact', '<i class="fa fa-envelope"></i>', 'Contact Us', 'fab--contact');
     const joinFab = createFab('join', '<i class="fa fa-user-plus"></i>', 'Join Us', 'fab--join');
     const chatbotFab = createFab('chatbot', '<i class="fa fa-comments"></i>', 'Chatbot', 'fab--chatbot');
+    menuFab = createFab('menu', '<i class="fa fa-bars"></i>', 'Menu', 'fab--menu');
 
     fabStack.appendChild(contactFab);
     fabStack.appendChild(joinFab);
     fabStack.appendChild(chatbotFab);
+    fabStack.appendChild(menuFab);
 
     contactFab.addEventListener('click', () => showModal('contact'));
     joinFab.addEventListener('click', () => showModal('join'));
     chatbotFab.addEventListener('click', () => showModal('chatbot'));
+    menuFab.addEventListener('click', () => {
+      const navToggle = document.querySelector('.nav-menu-toggle');
+      if (navToggle && navToggle.click) {
+        navToggle.click();
+      }
+    });
   }
 
   function updateMenuFab() {
     const navToggle = document.querySelector('.nav-menu-toggle');
     const shouldShow = navToggle && isMobileWidth();
-    if (shouldShow && !menuFab) {
-      menuFab = createFab('menu', '<i class="fa fa-bars"></i>', 'Menu', 'fab--menu');
-      menuFab.addEventListener('click', () => {
-        const navToggle = document.querySelector('.nav-menu-toggle');
-        if (navToggle && navToggle.click) {
-          navToggle.click();
-        }
-      });
-      fabStack.appendChild(menuFab);
-    } else if (!shouldShow && menuFab) {
-      menuFab.remove();
-      menuFab = null;
-      if (navToggle && navToggle.getAttribute('aria-expanded') === 'true' && navToggle.click) {
-        navToggle.click();
-      }
+    if (menuFab) {
+      menuFab.hidden = !shouldShow;
+    }
+    if (!shouldShow && navToggle && navToggle.getAttribute('aria-expanded') === 'true' && navToggle.click) {
+      navToggle.click();
     }
   }
 

--- a/contact-center.html
+++ b/contact-center.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://placehold.co https://*.hcaptcha.com; style-src 'self' https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css https://*.hcaptcha.com; font-src 'self' https://cdnjs.cloudflare.com; script-src 'self' 'sha256-4c8551ea60359723cbf8d33588ce9cfc11ba0841b8053ec6720bcea21a63a6eb' 'sha256-9af4270cfe68577b4026bac190e45957f471ba3e3bf6beda4dd353b10d0ccf65' 'sha256-3fa65aa46ad3e855cbc0c69536eb383d3f788f7561d271f7e535982acc173b9a' 'sha256-1712eb7f144fbb26d28e689e5f82933bbd3f876a41bf4551c1764e17ab0aea77' 'sha256-47b5eea8ed1cb5829fecdf8c01e8d2d63018b26330323255d5c5e8c396a14518' https://*.hcaptcha.com; connect-src 'self' https://*.hcaptcha.com; object-src 'none'; base-uri 'self'; frame-src https://*.hcaptcha.com;" />
   <title data-key="title-contact-center">Contact Center | Ops Online Support</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <link rel="stylesheet" href="css/style.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha512-Fo3rlrZj/k7ujTnHg4CGR2D7kSs0v4LLanw2qksYuRlEzO+tcaEPQogQ0KaoGN26/zrn20ImR1DfuLWnOo7aBA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="fabs/css/cojoin.css">

--- a/css/style.css
+++ b/css/style.css
@@ -36,7 +36,7 @@
   --space-2xl: 3.125rem;
   --space-3xl: 3.75rem;
   /* Fallback viewport unit */
-  --vh: 1vh;
+  --vh: 1dvh;
 }
 
 /* Dark Theme Variables */
@@ -84,7 +84,6 @@ html {
 
 body {
   font-family: "Segoe UI", Arial, sans-serif;
-  min-height: 100vh;
   min-height: calc(var(--vh, 1vh) * 100);
   margin: 0;
   color: var(--clr-text-subtle);
@@ -105,13 +104,15 @@ body.dark {
 }
 
 main {
-  max-width: 75rem;
+  max-width: 90vw;
   margin: 0 auto;
   padding: 0 var(--space-md);
+  padding-left: calc(var(--space-md) + env(safe-area-inset-left));
+  padding-right: calc(var(--space-md) + env(safe-area-inset-right));
 }
 
 header, section {
-  max-width: 56.25rem;
+  max-width: 85vw;
   margin: 0 auto var(--space-xl);
   text-align: center;
 }
@@ -164,12 +165,12 @@ li {
   z-index: 1000;
   background: var(--clr-background);
   width: 100%;
-  max-width: 77.5rem;
+  max-width: 95vw;
   margin: 0 auto;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  height: 64px;
+  height: 4rem;
   padding: 0 2rem;
   padding-left: calc(2rem + env(safe-area-inset-left));
   padding-right: calc(2rem + env(safe-area-inset-right));
@@ -195,18 +196,22 @@ li {
   position: fixed;
   top: 0;
   right: 0;
-  height: 100%;
+  height: 100dvh;
   width: 70%;
-  max-width: 300px;
+  max-width: 80vw;
   display: flex;
   flex-direction: column;
   margin-top: 0;
   background: var(--clr-background);
-  border-left: 1px solid var(--clr-form-border);
-  border-radius: 5px 0 0 5px;
+  border-left: 0.0625rem solid var(--clr-form-border);
+  border-radius: 0.3125rem 0 0 0.3125rem;
   transform: translateX(100%);
   transition: transform 0.3s ease;
   padding: var(--space-xl) var(--space-md);
+  padding-top: calc(var(--space-xl) + env(safe-area-inset-top));
+  padding-bottom: calc(var(--space-xl) + env(safe-area-inset-bottom));
+  padding-left: calc(var(--space-md) + env(safe-area-inset-left));
+  padding-right: calc(var(--space-md) + env(safe-area-inset-right));
   z-index: 1000;
 }
 
@@ -221,7 +226,7 @@ li {
   position: relative;
   transition: color 0.18s;
   text-decoration: none;
-  border-bottom: 1px solid var(--clr-form-border);
+  border-bottom: 0.0625rem solid var(--clr-form-border);
 }
 
 .nav-link:last-child {
@@ -348,10 +353,10 @@ li {
 
 .cta-button.it-and-contact {
   background: linear-gradient(45deg, var(--clr-cta-other), #7e57c2);
-  padding: 14px 30px;
+  padding: 0.875rem 1.875rem;
   font-size: 1.1rem;
-  border-radius: 10px;
-  box-shadow: 0 8px 25px rgba(171, 71, 188, 0.6);
+  border-radius: 0.625rem;
+  box-shadow: 0 0.5rem 1.5625rem rgba(171, 71, 188, 0.6);
 }
 
 .cta-button.it-and-contact:hover {
@@ -364,9 +369,9 @@ li {
   max-width: 100%;
   margin: 0 auto var(--space-3xl);
   background: var(--clr-form-bg);
-  padding: 0 15px;
-  border-radius: 14px;
-  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.2);
+  padding: 0 0.9375rem;
+  border-radius: 0.875rem;
+  box-shadow: 0 0.5rem 2.5rem rgba(0, 0, 0, 0.2);
   transition: background 0.3s, color 0.3s;
 }
 
@@ -418,13 +423,15 @@ li {
 
 /* Business Ops Specific Components */
 .grid-container {
-  max-width: 75rem;
+  max-width: 90vw;
   margin: 0 auto;
   margin-top: 2.8rem;
   display: grid;
-  gap: 50px; /* ≈200 px total spacing (3 gaps × 50px + 50px outer margins) */
+  gap: 3.125rem; /* ≈12.5rem total spacing (3 gaps × 3.125rem + 3.125rem outer margins) */
   grid-template-columns: 1fr;
-  padding: 0 1rem;
+  padding: 0;
+  padding-left: calc(1rem + env(safe-area-inset-left));
+  padding-right: calc(1rem + env(safe-area-inset-right));
 }
 
 .card {
@@ -679,12 +686,12 @@ body.dark .ops-modal {
     font-size: 2.4rem;
   }
   .cta-button.it-and-contact {
-    padding: 14px 34px;
+    padding: 0.875rem 2.125rem;
     font-size: 1.12rem;
   }
   .contact-form-section {
-    padding: 24px 24px 32px;
-    max-width: 460px;
+    padding: 1.5rem 1.5rem 2rem;
+    max-width: 70vw;
   }
 }
 
@@ -693,12 +700,12 @@ body.dark .ops-modal {
     font-size: 2.8rem;
   }
   .cta-button.it-and-contact {
-    padding: 16px 38px;
+    padding: 1rem 2.375rem;
     font-size: 1.15rem;
   }
   .contact-form-section {
-    padding: 30px 30px 40px;
-    max-width: 480px;
+    padding: 1.875rem 1.875rem 2.5rem;
+    max-width: 60vw;
   }
 }
 
@@ -752,7 +759,7 @@ body.dark .ops-modal {
 
 @media (min-width: 1024px) {
   .grid-container {
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(25%, 1fr));
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://placehold.co https://*.hcaptcha.com; style-src 'self' https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css https://*.hcaptcha.com; font-src 'self' https://cdnjs.cloudflare.com; script-src 'self' 'sha256-4c8551ea60359723cbf8d33588ce9cfc11ba0841b8053ec6720bcea21a63a6eb' 'sha256-9af4270cfe68577b4026bac190e45957f471ba3e3bf6beda4dd353b10d0ccf65' 'sha256-3fa65aa46ad3e855cbc0c69536eb383d3f788f7561d271f7e535982acc173b9a' 'sha256-1712eb7f144fbb26d28e689e5f82933bbd3f876a41bf4551c1764e17ab0aea77' 'sha256-47b5eea8ed1cb5829fecdf8c01e8d2d63018b26330323255d5c5e8c396a14518' https://*.hcaptcha.com; connect-src 'self' https://*.hcaptcha.com; object-src 'none'; base-uri 'self'; frame-src https://*.hcaptcha.com;" />
   <title data-key="title-business-ops">Business Operations | Ops Online Support</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <link rel="stylesheet" href="css/style.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha512-Fo3rlrZj/k7ujTnHg4CGR2D7kSs0v4LLanw2qksYuRlEzO+tcaEPQogQ0KaoGN26/zrn20ImR1DfuLWnOo7aBA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="fabs/css/cojoin.css">

--- a/it-support.html
+++ b/it-support.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://placehold.co https://*.hcaptcha.com; style-src 'self' https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css https://*.hcaptcha.com; font-src 'self' https://cdnjs.cloudflare.com; script-src 'self' 'sha256-4c8551ea60359723cbf8d33588ce9cfc11ba0841b8053ec6720bcea21a63a6eb' 'sha256-9af4270cfe68577b4026bac190e45957f471ba3e3bf6beda4dd353b10d0ccf65' 'sha256-3fa65aa46ad3e855cbc0c69536eb383d3f788f7561d271f7e535982acc173b9a' 'sha256-1712eb7f144fbb26d28e689e5f82933bbd3f876a41bf4551c1764e17ab0aea77' 'sha256-47b5eea8ed1cb5829fecdf8c01e8d2d63018b26330323255d5c5e8c396a14518' https://*.hcaptcha.com; connect-src 'self' https://*.hcaptcha.com; object-src 'none'; base-uri 'self'; frame-src https://*.hcaptcha.com;" />
   <title data-key="title-it-support">IT Support | Ops Online Support</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <link rel="stylesheet" href="css/style.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha512-Fo3rlrZj/k7ujTnHg4CGR2D7kSs0v4LLanw2qksYuRlEzO+tcaEPQogQ0KaoGN26/zrn20ImR1DfuLWnOo7aBA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="fabs/css/cojoin.css">

--- a/professional-services.html
+++ b/professional-services.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' https://placehold.co https://*.hcaptcha.com; style-src 'self' https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css https://*.hcaptcha.com; font-src 'self' https://cdnjs.cloudflare.com; script-src 'self' 'sha256-4c8551ea60359723cbf8d33588ce9cfc11ba0841b8053ec6720bcea21a63a6eb' 'sha256-9af4270cfe68577b4026bac190e45957f471ba3e3bf6beda4dd353b10d0ccf65' 'sha256-3fa65aa46ad3e855cbc0c69536eb383d3f788f7561d271f7e535982acc173b9a' 'sha256-1712eb7f144fbb26d28e689e5f82933bbd3f876a41bf4551c1764e17ab0aea77' 'sha256-47b5eea8ed1cb5829fecdf8c01e8d2d63018b26330323255d5c5e8c396a14518' https://*.hcaptcha.com; connect-src 'self' https://*.hcaptcha.com; object-src 'none'; base-uri 'self'; frame-src https://*.hcaptcha.com;" />
   <title data-key="title-professionals">Professional Services | Ops Online Support</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <link rel="stylesheet" href="css/style.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" integrity="sha512-Fo3rlrZj/k7ujTnHg4CGR2D7kSs0v4LLanw2qksYuRlEzO+tcaEPQogQ0KaoGN26/zrn20ImR1DfuLWnOo7aBA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="fabs/css/cojoin.css">


### PR DESCRIPTION
## Summary
- apply `width=device-width, initial-scale=1, viewport-fit=cover` on all entry pages
- convert fixed pixel spacing to rem and layout dimensions to responsive units with safe-area padding
- harden FAB script with `matchMedia` fallback and persistent menu button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68979e6ecd68832ba59b2e85a8f70669