### PR TITLE
Add mobile accessibility CI workflow

### DIFF
--- a/.github/workflows/ops-mobile-ci.yml
+++ b/.github/workflows/ops-mobile-ci.yml
@@ -1,0 +1,17 @@
+name: ops-mobile-ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npx playwright install --with-deps chromium
+      - run: npm run ci:test

--- a/ops_mobile_ci.js
+++ b/ops_mobile_ci.js
@@ -1,5 +1,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
+const httpServer = require('http-server');
+const { chromium } = require('playwright');
 
 // Pages used in mobile CI checks. Ensure each page includes
 // the FAB loader script so modal tests can run properly.
@@ -11,17 +13,55 @@ const pages = [
   '/fabs/join.html'
 ];
 
-const root = __dirname;
+async function run() {
+  const root = __dirname;
+  const port = 8080;
+  const server = httpServer.createServer({ root });
+  await new Promise(resolve => server.listen(port, resolve));
 
-for (const page of pages) {
-  const filePath = path.join(root, page);
-  const html = fs.readFileSync(filePath, 'utf8');
-  // Modal fragments under /fabs/ don't include FAB buttons directly.
-  if (!page.startsWith('/fabs/')) {
-    if (!html.includes('cojoinlistener.js')) {
-      throw new Error(`FAB buttons missing on ${page}`);
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 375, height: 667 } });
+  const axeSource = fs.readFileSync(require.resolve('axe-core/axe.min.js'), 'utf8');
+
+  let hasViolations = false;
+
+  for (const route of pages) {
+    const filePath = path.join(root, route);
+    // Modal fragments under /fabs/ don't include FAB buttons directly.
+    if (!route.startsWith('/fabs/')) {
+      const html = fs.readFileSync(filePath, 'utf8');
+      if (!html.includes('cojoinlistener.js')) {
+        throw new Error(`FAB buttons missing on ${route}`);
+      }
     }
+
+    const url = `http://localhost:${port}${route}`;
+    await page.goto(url);
+    await page.addScriptTag({ content: axeSource });
+    const results = await page.evaluate(async () => {
+      return await axe.run();
+    });
+
+    if (results.violations.length > 0) {
+      console.error(`Accessibility issues on ${route}:`);
+      for (const v of results.violations) {
+        console.error(`- ${v.id}: ${v.description}`);
+      }
+      hasViolations = true;
+    } else {
+      console.log(`${route}: no accessibility violations`);
+    }
+  }
+
+  await browser.close();
+  await new Promise(resolve => server.close(resolve));
+
+  if (hasViolations) {
+    process.exit(1);
   }
 }
 
-module.exports = pages;
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "devDependencies": {
     "axe-core": "^4.9.1",
     "jsdom": "^26.1.0",
-    "playwright": "^1.47.2"
+    "playwright": "^1.47.2",
+    "http-server": "^14.1.1"
   },
   "keywords": [],
   "license": "ISC",


### PR DESCRIPTION
## Summary
- add Playwright + axe-core script for mobile CI
- register http-server dev dependency and CI test script
- configure GitHub Actions workflow to run mobile validator

## Testing
- `npm test` *(fails: fab stack renders buttons in order)*
- `npm run ci:test` *(fails: Cannot find module 'http-server')*


------
https://chatgpt.com/codex/tasks/task_e_68979e7f9a5c832ba5aa2faf1f3423c5