### PR TITLE
feat: add responsive drawer and bottom sheet snapping

### DIFF
--- a/fabs/contact.html
+++ b/fabs/contact.html
@@ -1,11 +1,12 @@
 <!-- This is a fragment, intended to be loaded dynamically -->
 <div id="modal-contact-center" class="modal-container" role="dialog" aria-modal="true">
-  <div class="modal__header">
-    <h1>Contact Us</h1>
-    <button class="modal-close"><i class="fas fa-times"></i></button>
-  </div>
-  <div class="modal-content">
-    <form id="contactForm" autocomplete="off">
+  <div id="drawer-mobile">
+    <div class="modal__header">
+      <h1>Contact Us</h1>
+      <button class="modal-close"><i class="fas fa-times"></i></button>
+    </div>
+    <div class="modal-content">
+      <form id="contactForm" autocomplete="off">
       <div class="form-errors" aria-live="polite"></div>
       <div class="form-row">
         <div class="form-cell">
@@ -57,9 +58,10 @@
         <input type="text" id="honeypot-contact" name="honeypot-contact" />
       </div>
 
-      <div class="modal__footer">
-        <button type="submit" class="submit-btn">Send</button>
-      </div>
-    </form>
+        <div class="modal__footer">
+          <button type="submit" class="submit-btn">Send</button>
+        </div>
+      </form>
+    </div>
   </div>
 </div>

--- a/fabs/css/cojoin.css
+++ b/fabs/css/cojoin.css
@@ -103,6 +103,38 @@ body[data-lock="true"] {
   display: block;
 }
 
+/* Mobile Drawer */
+#drawer-mobile {
+  position: fixed;
+  left: 50%;
+  bottom: 0;
+  transform: translateX(-50%);
+  width: clamp(72vw, 80vw, 88vw);
+  max-height: 100dvh;
+  background: var(--clr-bg);
+  border-radius: 0.75rem 0.75rem 0 0;
+  box-shadow: 0 -0.5rem 1rem rgba(0, 0, 0, 0.25);
+  z-index: 1002;
+  display: none;
+  overflow: hidden;
+  touch-action: none;
+  transition: height 0.3s ease;
+}
+
+@media (min-width: 768px) {
+  #drawer-mobile {
+    width: clamp(360px, 390px, 420px);
+  }
+}
+
+#drawer-mobile[data-open="true"] {
+  display: block;
+}
+
+#drawer-mobile[data-snap="40"] { height: 40dvh; }
+#drawer-mobile[data-snap="70"] { height: 70dvh; }
+#drawer-mobile[data-snap="100"] { height: 100dvh; }
+
 .modal-container {
   position: fixed;
   top: 50%;

--- a/fabs/join.html
+++ b/fabs/join.html
@@ -1,11 +1,12 @@
 <!-- This is a fragment, intended to be loaded dynamically -->
 <div id="modal-join-us" class="modal-container" role="dialog" aria-modal="true">
-  <div class="modal__header">
-    <h1>Join Us</h1>
-    <button class="modal-close"><i class="fas fa-times"></i></button>
-  </div>
-  <div class="modal-content">
-    <form id="joinForm" autocomplete="off" novalidate>
+  <div id="drawer-mobile">
+    <div class="modal__header">
+      <h1>Join Us</h1>
+      <button class="modal-close"><i class="fas fa-times"></i></button>
+    </div>
+    <div class="modal-content">
+      <form id="joinForm" autocomplete="off" novalidate>
       <div class="form-errors" aria-live="polite"></div>
       <div class="form-pairs">
         <div>
@@ -124,9 +125,10 @@
         <input type="text" id="honeypot-join" name="honeypot-join" />
       </div>
 
-      <div class="modal__footer">
-        <button type="submit" class="submit-btn">Submit</button>
-      </div>
-    </form>
+        <div class="modal__footer">
+          <button type="submit" class="submit-btn">Submit</button>
+        </div>
+      </form>
+    </div>
   </div>
 </div>

--- a/fabs/js/cojoin.js
+++ b/fabs/js/cojoin.js
@@ -7,9 +7,10 @@
  */
 
 function initCojoinForms() {
-
   const contactForm = document.getElementById('contactForm');
   const joinForm = document.getElementById('joinForm');
+
+  initBottomSheet();
 
   function showFormError(form, message) {
     const region = form.querySelector('.form-errors');
@@ -361,6 +362,57 @@ function initCojoinForms() {
       section.classList.remove('completed');
     }
   }
+}
+
+function initBottomSheet() {
+  const drawers = document.querySelectorAll('#drawer-mobile');
+  drawers.forEach(drawer => {
+    if (drawer.dataset.sheetInit) return;
+    drawer.dataset.sheetInit = 'true';
+
+    const header = drawer.querySelector('.modal__header');
+    const snapPoints = [40, 70, 100];
+
+    const setSnap = (val) => {
+      let closest = snapPoints[0];
+      snapPoints.forEach(p => {
+        if (Math.abs(p - val) < Math.abs(closest - val)) {
+          closest = p;
+        }
+      });
+      drawer.dataset.snap = String(closest);
+      drawer.style.height = `${closest}dvh`;
+    };
+
+    let startY = 0;
+    let startHeight = 0;
+
+    function onPointerMove(e) {
+      const diff = startY - e.clientY;
+      const newHeight = ((startHeight + diff) / window.innerHeight) * 100;
+      drawer.style.height = `${newHeight}dvh`;
+    }
+
+    function onPointerUp(e) {
+      const diff = startY - e.clientY;
+      const newHeight = ((startHeight + diff) / window.innerHeight) * 100;
+      setSnap(newHeight);
+      document.removeEventListener('pointermove', onPointerMove);
+      document.removeEventListener('pointerup', onPointerUp);
+    }
+
+    if (header) {
+      header.addEventListener('pointerdown', (e) => {
+        startY = e.clientY;
+        startHeight = drawer.offsetHeight;
+        document.addEventListener('pointermove', onPointerMove);
+        document.addEventListener('pointerup', onPointerUp);
+      });
+    }
+
+    setSnap(40);
+    drawer.dataset.open = 'true';
+  });
 }
 
 if (typeof window.makeDraggable === 'function') {


### PR DESCRIPTION
## Summary
- introduce `#drawer-mobile` for mobile and tablet widths
- support bottom sheet snap points at 40/70/100dvh with pointer-driven drag
- wrap contact and join forms in the new drawer container

## Testing
- `npm test` *(fails: 1, passes: 43)*

------
https://chatgpt.com/codex/tasks/task_e_68979e81d184832bb850afe8b2db9d0b