### PR TITLE
Adjust chat icon and close button sizing

### DIFF
--- a/fabs/css/chatbot.css
+++ b/fabs/css/chatbot.css
@@ -80,9 +80,20 @@ body.dark{--clr-bg:var(--clr-bg-dark);--clr-tx:var(--clr-tx-dark)}
   transition:.3s;
   padding:0;
 }
-#chatbot-send i,#chatbot-close i{font-size:0.25em;transition:transform .3s}
+
+#chatbot-close{
+  width:20px;
+  height:20px;
+  margin-left:0;
+}
+
+#chatbot-send i,
+#chatbot-close i{
+  font-size:20px;
+  transition:transform .3s;
+}
+
 #chatbot-send:hover i{transform:rotate(-45deg)}
 #chatbot-send:disabled{background:#555;cursor:not-allowed}
-#chatbot-close{margin-left:0}
 .human-check{color:#ddd;font-size:.85rem;display:flex;align-items:center;margin-top:.3rem}
 .human-check input{margin-right:.4rem}


### PR DESCRIPTION
## Summary
- shrink chatbot close button to 20px
- ensure send and close icons render at 20px

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898c9a37478832ba7b6f24ea596e557